### PR TITLE
feat: mobile support

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm app husky:pre-commit

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,6 @@
 packages/asset-utils/hardcoded
 packages/asset-utils/output
 packages/asset-utils/workdir
+
+# editor temp files
+*.sw?

--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
   "version": "1.0.1",
   "scripts": {
     "app": "pnpm -F app",
-    "asset-utils": "pnpm -F asset-utils"
+    "asset-utils": "pnpm -F asset-utils",
+    "prepare": "husky"
   },
   "pnpm": {
     "overrides": {
       "three-mesh-bvh": "^0.8.0"
     }
   },
-  "packageManager": "pnpm@9.7.1+sha512.faf344af2d6ca65c4c5c8c2224ea77a81a5e8859cbc4e06b1511ddce2f0151512431dd19e6aff31f2c6a8f5f2aced9bd2273e1fed7dd4de1868984059d2c4247"
+  "packageManager": "pnpm@9.7.1+sha512.faf344af2d6ca65c4c5c8c2224ea77a81a5e8859cbc4e06b1511ddce2f0151512431dd19e6aff31f2c6a8f5f2aced9bd2273e1fed7dd4de1868984059d2c4247",
+  "devDependencies": {
+    "husky": "^9.1.7"
+  }
 }

--- a/packages/app/.gitignore
+++ b/packages/app/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# vim swap files
+*.sw?

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
     <title>Display Entity Platform</title>
 
     <meta name="og:title" content="Display Entity Platform" />

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -16,6 +16,13 @@
         <span>Please enable Javascript for this page from your browser to use this app.</span>
       </div>
     </noscript>
+    <script>
+      window.onerror = (e) => {
+        if (globalThis.__depl_alertUncaughtError) {
+          window.alert(e.stack ?? e)
+        }
+      }
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -58,5 +58,8 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.7.0",
     "vite": "^5.4.8"
+  },
+  "optionalDependencies": {
+    "@swc/core-android-arm64": "^1.3.11"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@eslint/js": "^9.11.1",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/lodash.merge": "^4.6.9",
     "@types/node": "^22.7.5",
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -32,7 +32,7 @@
     "r3f-perf": "^7.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-icons": "^5.3.0",
+    "react-icons": "^5.5.0",
     "swr": "^2.2.5",
     "tailwind-merge": "^2.5.3",
     "tailwindcss-animate": "^1.0.7",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write src",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "husky:pre-commit": "pretty-quick --staged --pattern \"packages/app/**/*.{js,ts,jsx,tsx,json}\""
   },
   "dependencies": {
     "@headlessui/react": "^2.1.10",
@@ -57,6 +58,7 @@
     "postcss": "^8.4.47",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.8",
+    "pretty-quick": "^4.2.2",
     "tailwindcss": "^3.4.13",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.7.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,6 +26,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.0.5",
     "immer": "^10.1.1",
+    "lodash.merge": "^4.6.2",
     "nanoid": "^5.0.7",
     "r3f-perf": "^7.2.3",
     "react": "^18.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -27,6 +27,7 @@
     "framer-motion": "^12.0.5",
     "immer": "^10.1.1",
     "nanoid": "^5.0.7",
+    "r3f-perf": "^7.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,6 +1,7 @@
 import Scene from './Scene'
 import Sidebar from './Sidebar'
 import LeftButtonPanel from './components/LeftButtonPanel'
+import MobileBottomButtonPanel from './components/MobileBottomButtonPanel'
 import TopButtonPanel from './components/TopButtonPanel'
 import BlockDisplaySelectDialog from './components/dialog/BlockDisplaySelectDialog'
 import ExportToMinecraftDialog from './components/dialog/ExportToMinecraftDialog'
@@ -9,13 +10,14 @@ import SettingsDialog from './components/dialog/SettingsDialog'
 
 function App() {
   return (
-    <div className="flex h-full w-full flex-row">
-      <div className="relative flex-1 overflow-hidden">
+    <div className="relative h-full w-full overflow-hidden xs:flex xs:flex-row">
+      <div className="relative h-full w-full flex-1">
         <Scene />
 
         {/* floating buttons */}
         <TopButtonPanel />
         <LeftButtonPanel />
+        <MobileBottomButtonPanel />
       </div>
 
       <Sidebar />

--- a/packages/app/src/Scene.tsx
+++ b/packages/app/src/Scene.tsx
@@ -1,8 +1,8 @@
 import { Grid, PerspectiveCamera } from '@react-three/drei'
 import { Canvas, invalidate } from '@react-three/fiber'
-import { FC } from 'react'
-import { Color } from 'three'
 import { Perf } from 'r3f-perf'
+import { FC, useEffect, useRef } from 'react'
+import { Color } from 'three'
 
 import CustomCameraControls from './CustomCameraControls'
 import DisplayentitiesRootGroup from './components/DisplayEntitiesRootGroup'
@@ -12,13 +12,34 @@ import TransformControls from './components/TransformControls'
 import { useDisplayEntityStore } from './stores/displayEntityStore'
 
 const Scene: FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const preventDefault = (e: TouchEvent) => e.preventDefault()
+
+    canvas.addEventListener('touchmove', preventDefault, { passive: false })
+    canvas.addEventListener('gesturestart', preventDefault, { passive: false }) // For Safari
+
+    return () => {
+      canvas.removeEventListener('touchmove', preventDefault)
+      canvas.removeEventListener('gesturestart', preventDefault)
+    }
+  }, [])
+
   return (
     <Canvas
+      ref={canvasRef}
       // temporaily set to 'always' because r3f-perf requires to work properly
       // TODO: make debug settings > show perf monitor option and change value according to that setting
       frameloop="always"
       scene={{
         background: new Color(0x222222),
+      }}
+      style={{
+        touchAction: 'none',
       }}
       onPointerDown={() => {
         // frameloop="demand"일 경우 가끔 TransformControls가 작동하지 않는 경우가 발생하는데
@@ -87,7 +108,7 @@ const Scene: FC = () => {
         infiniteGrid
       />
 
-      <Perf position="bottom-left"/>
+      <Perf position="bottom-left" />
     </Canvas>
   )
 }

--- a/packages/app/src/Scene.tsx
+++ b/packages/app/src/Scene.tsx
@@ -18,6 +18,9 @@ const Scene: FC = () => {
   const perfMonitorEnabled = useEditorStore(
     (state) => state.settings.debug.perfMonitorEnabled,
   )
+  const reducePixelRatio = useEditorStore(
+    (state) => state.settings.performance.reducePixelRatio,
+  )
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -45,6 +48,7 @@ const Scene: FC = () => {
       style={{
         touchAction: 'none',
       }}
+      dpr={reducePixelRatio ? Math.min(window.devicePixelRatio, 1) : undefined}
       onPointerDown={() => {
         // frameloop="demand"일 경우 가끔 TransformControls가 작동하지 않는 경우가 발생하는데
         // 이를 방지하기 위해 클릭 시 강제로 다음 프레임 렌더링하도록 하여 다시 작동하도록 고치기

--- a/packages/app/src/Scene.tsx
+++ b/packages/app/src/Scene.tsx
@@ -2,6 +2,7 @@ import { Grid, PerspectiveCamera } from '@react-three/drei'
 import { Canvas, invalidate } from '@react-three/fiber'
 import { FC } from 'react'
 import { Color } from 'three'
+import { Perf } from 'r3f-perf'
 
 import CustomCameraControls from './CustomCameraControls'
 import DisplayentitiesRootGroup from './components/DisplayEntitiesRootGroup'
@@ -13,7 +14,9 @@ import { useDisplayEntityStore } from './stores/displayEntityStore'
 const Scene: FC = () => {
   return (
     <Canvas
-      frameloop="demand"
+      // temporaily set to 'always' because r3f-perf requires to work properly
+      // TODO: make debug settings > show perf monitor option and change value according to that setting
+      frameloop="always"
       scene={{
         background: new Color(0x222222),
       }}
@@ -83,6 +86,8 @@ const Scene: FC = () => {
         sectionSize={1}
         infiniteGrid
       />
+
+      <Perf position="bottom-left"/>
     </Canvas>
   )
 }

--- a/packages/app/src/Scene.tsx
+++ b/packages/app/src/Scene.tsx
@@ -112,7 +112,7 @@ const Scene: FC = () => {
         infiniteGrid
       />
 
-      {perfMonitorEnabled && <Perf position="bottom-left" />}
+      {perfMonitorEnabled && <Perf position="bottom-left" className="z-10" />}
     </Canvas>
   )
 }

--- a/packages/app/src/Scene.tsx
+++ b/packages/app/src/Scene.tsx
@@ -1,12 +1,12 @@
 import { Grid, PerspectiveCamera } from '@react-three/drei'
 import { Canvas, invalidate } from '@react-three/fiber'
-import { Perf } from 'r3f-perf'
 import { FC, useEffect, useRef } from 'react'
 import { Color } from 'three'
 
 import CustomCameraControls from './CustomCameraControls'
 import DisplayentitiesRootGroup from './components/DisplayEntitiesRootGroup'
 import DragSelectControl from './components/DragSelectControl'
+import Perf from './components/Perf'
 import ShortcutHandler from './components/ShortcutHandler'
 import TransformControls from './components/TransformControls'
 import { useDisplayEntityStore } from './stores/displayEntityStore'
@@ -40,8 +40,7 @@ const Scene: FC = () => {
   return (
     <Canvas
       ref={canvasRef}
-      // r3f-perf requires frameloop 'always' to work properly
-      frameloop={perfMonitorEnabled ? 'always' : 'demand'}
+      frameloop="demand"
       scene={{
         background: new Color(0x222222),
       }}
@@ -116,7 +115,7 @@ const Scene: FC = () => {
         infiniteGrid
       />
 
-      {perfMonitorEnabled && <Perf position="bottom-left" className="z-10" />}
+      {perfMonitorEnabled && <Perf />}
     </Canvas>
   )
 }

--- a/packages/app/src/Scene.tsx
+++ b/packages/app/src/Scene.tsx
@@ -26,7 +26,7 @@ const Scene: FC = () => {
     const canvas = canvasRef.current
     if (!canvas) return
 
-    const preventDefault = (e: TouchEvent) => e.preventDefault()
+    const preventDefault = (e: Event) => e.preventDefault()
 
     canvas.addEventListener('touchmove', preventDefault, { passive: false })
     canvas.addEventListener('gesturestart', preventDefault, { passive: false }) // For Safari

--- a/packages/app/src/Scene.tsx
+++ b/packages/app/src/Scene.tsx
@@ -53,8 +53,12 @@ const Scene: FC = () => {
         // 이를 방지하기 위해 클릭 시 강제로 다음 프레임 렌더링하도록 하여 다시 작동하도록 고치기
         invalidate()
       }}
-      onPointerMissed={() => {
-        useDisplayEntityStore.getState().setSelected([])
+      onPointerMissed={(evt) => {
+        // 모바일환경에서 TransformControls 잡은 상태로 꾹 누르고 있으면 contextmenu(우클릭) pointer event가 여기로 호출되는데
+        // 이때 TransformControls는 아직 잡혀 있는데 선택이 풀리면서 상태가 꼬여버리므로 이를 방지
+        if (evt.type !== 'contextmenu') {
+          useDisplayEntityStore.getState().setSelected([])
+        }
       }}
     >
       {/* Axis lines */}

--- a/packages/app/src/Scene.tsx
+++ b/packages/app/src/Scene.tsx
@@ -10,9 +10,14 @@ import DragSelectControl from './components/DragSelectControl'
 import ShortcutHandler from './components/ShortcutHandler'
 import TransformControls from './components/TransformControls'
 import { useDisplayEntityStore } from './stores/displayEntityStore'
+import { useEditorStore } from './stores/editorStore'
 
 const Scene: FC = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  const perfMonitorEnabled = useEditorStore(
+    (state) => state.settings.debug.perfMonitorEnabled,
+  )
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -32,9 +37,8 @@ const Scene: FC = () => {
   return (
     <Canvas
       ref={canvasRef}
-      // temporaily set to 'always' because r3f-perf requires to work properly
-      // TODO: make debug settings > show perf monitor option and change value according to that setting
-      frameloop="always"
+      // r3f-perf requires frameloop 'always' to work properly
+      frameloop={perfMonitorEnabled ? 'always' : 'demand'}
       scene={{
         background: new Color(0x222222),
       }}
@@ -108,7 +112,7 @@ const Scene: FC = () => {
         infiniteGrid
       />
 
-      <Perf position="bottom-left" />
+      {perfMonitorEnabled && <Perf position="bottom-left" />}
     </Canvas>
   )
 }

--- a/packages/app/src/Sidebar.tsx
+++ b/packages/app/src/Sidebar.tsx
@@ -1,16 +1,40 @@
 import { FC } from 'react'
+import { useShallow } from 'zustand/shallow'
 
 import ObjectsPanel from './components/sidebar/ObjectsPanel'
 import PropertiesPanel from './components/sidebar/PropertiesPanel'
 import TransformsPanel from './components/sidebar/TransformsPanel'
+import { useEditorStore } from './stores/editorStore'
+import { cn } from './utils'
 
 const Sidebar: FC = () => {
+  const { mobileSidebarOpened, setMobileSidebarOpened } = useEditorStore(
+    useShallow((state) => ({
+      mobileSidebarOpened: state.mobileSidebarOpened,
+      setMobileSidebarOpened: state.setMobileSidebarOpened,
+    })),
+  )
+
   return (
-    <div className="flex w-[400px] flex-col gap-2 overflow-y-auto p-2">
-      <ObjectsPanel />
-      <TransformsPanel />
-      <PropertiesPanel />
-    </div>
+    <>
+      <div
+        className={cn(
+          'absolute right-0 top-0 z-40 h-full w-full bg-black/50 transition duration-200 sm:hidden',
+          mobileSidebarOpened ? 'opacity-1' : 'pointer-events-none opacity-0',
+        )}
+        onClick={() => setMobileSidebarOpened(false)}
+      />
+      <div
+        className={cn(
+          'fixed right-0 top-0 z-50 flex h-full w-full max-w-[300px] flex-col gap-2 overflow-y-auto bg-neutral-800 p-2 transition duration-200 ease-out xs:static xs:max-w-[400px]',
+          !mobileSidebarOpened && 'translate-x-full xs:translate-x-0',
+        )}
+      >
+        <ObjectsPanel />
+        <TransformsPanel />
+        <PropertiesPanel />
+      </div>
+    </>
   )
 }
 

--- a/packages/app/src/components/DragSelectControl.tsx
+++ b/packages/app/src/components/DragSelectControl.tsx
@@ -6,6 +6,7 @@ import { Group, Vector2, Vector3 } from 'three'
 import { shallow } from 'zustand/shallow'
 
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
+import { useEditorStore } from '@/stores/editorStore'
 import { useEntityRefStore } from '@/stores/entityRefStore'
 import { cn } from '@/utils'
 
@@ -74,7 +75,8 @@ const DragSelectControl: FC<DragSelectControlProps> = ({
     }
 
     const pointerDown = (evt: PointerEvent) => {
-      if (!evt.ctrlKey) return
+      const { mobileDragHoldButtonPressed } = useEditorStore.getState()
+      if (!evt.ctrlKey && !mobileDragHoldButtonPressed) return
 
       // canvas 공간 밖에서 드래그를 시작했을 경우 처리하지 않음
       const canvasElement = gl.domElement

--- a/packages/app/src/components/FloatingButton.tsx
+++ b/packages/app/src/components/FloatingButton.tsx
@@ -7,12 +7,13 @@ interface FloatingButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const FloatingButton = forwardRef<HTMLButtonElement, FloatingButtonProps>(
-  ({ children, active = false, ...props }, ref) => {
+  ({ children, active = false, className, ...props }, ref) => {
     return (
       <button
         className={cn(
           'rounded-lg p-2 outline-none',
           active ? 'bg-neutral-300 text-black' : 'bg-black text-neutral-300',
+          className,
         )}
         {...props}
         ref={ref}

--- a/packages/app/src/components/FullscreenToggle.tsx
+++ b/packages/app/src/components/FullscreenToggle.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+import { LuMaximize, LuMinimize } from 'react-icons/lu'
+
+const FullscreenToggle = () => {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  const toggleFullscreen = () => {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen().catch((err) => {
+        console.error('Error attempting to enable fullscreen:', err)
+      })
+    } else {
+      document.exitFullscreen().catch((err) => {
+        console.error('Error attempting to exit fullscreen:', err)
+      })
+    }
+  }
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement)
+    }
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange)
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange)
+    }
+  }, [])
+
+  return (
+    <button className="rounded-lg bg-black p-2" onClick={toggleFullscreen}>
+      {isFullscreen ? <LuMinimize size={24}/> : <LuMaximize size={24} />}
+    </button>
+  )
+}
+
+export default FullscreenToggle

--- a/packages/app/src/components/FullscreenToggle.tsx
+++ b/packages/app/src/components/FullscreenToggle.tsx
@@ -29,7 +29,7 @@ const FullscreenToggle = () => {
 
   return (
     <button className="rounded-lg bg-black p-2" onClick={toggleFullscreen}>
-      {isFullscreen ? <LuMinimize size={24}/> : <LuMaximize size={24} />}
+      {isFullscreen ? <LuMinimize size={24} /> : <LuMaximize size={24} />}
     </button>
   )
 }

--- a/packages/app/src/components/LeftButtonPanel.tsx
+++ b/packages/app/src/components/LeftButtonPanel.tsx
@@ -10,6 +10,7 @@ import { useDialogStore } from '@/stores/dialogStore'
 import { useEditorStore } from '@/stores/editorStore'
 
 import FloatingButton from './FloatingButton'
+import MobileDragHoldButton from './MobileDragHoldButton'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -136,6 +137,12 @@ const LeftButtonPanel: FC = () => {
         >
           <LuMoveDiagonal size={24} />
         </FloatingButton>
+      </Tooltip>
+
+      <div />
+
+      <Tooltip>
+        <MobileDragHoldButton />
       </Tooltip>
     </div>
   )

--- a/packages/app/src/components/MobileBottomButtonPanel.tsx
+++ b/packages/app/src/components/MobileBottomButtonPanel.tsx
@@ -1,3 +1,5 @@
+import { FC } from 'react'
+
 import { LuPanelRightOpen } from 'react-icons/lu'
 import { useShallow } from 'zustand/shallow'
 
@@ -6,9 +8,8 @@ import { useEditorStore } from '@/stores/editorStore'
 import FullscreenToggle from './FullscreenToggle'
 
 const MobileBottomButtonPanel: FC = () => {
-  const { mobileSidebarOpened, setMobileSidebarOpened } = useEditorStore(
+  const { setMobileSidebarOpened } = useEditorStore(
     useShallow((state) => ({
-      mobileSidebarOpened: state.mobileSidebarOpened,
       setMobileSidebarOpened: state.setMobileSidebarOpened,
     })),
   )

--- a/packages/app/src/components/MobileBottomButtonPanel.tsx
+++ b/packages/app/src/components/MobileBottomButtonPanel.tsx
@@ -2,6 +2,7 @@ import { LuPanelRightOpen } from 'react-icons/lu'
 import { useShallow } from 'zustand/shallow'
 
 import { useEditorStore } from '@/stores/editorStore'
+import FullscreenToggle from './FullscreenToggle'
 
 const MobileBottomButtonPanel: FC = () => {
   const { mobileSidebarOpened, setMobileSidebarOpened } = useEditorStore(
@@ -13,6 +14,7 @@ const MobileBottomButtonPanel: FC = () => {
 
   return (
     <div className="fixed bottom-4 right-4 flex flex-col gap-2 xs:hidden">
+      <FullscreenToggle />
       <button
         className="rounded-lg bg-black p-2"
         onClick={() => setMobileSidebarOpened(true)}

--- a/packages/app/src/components/MobileBottomButtonPanel.tsx
+++ b/packages/app/src/components/MobileBottomButtonPanel.tsx
@@ -1,0 +1,26 @@
+import { LuPanelRightOpen } from 'react-icons/lu'
+import { useShallow } from 'zustand/shallow'
+
+import { useEditorStore } from '@/stores/editorStore'
+
+const MobileBottomButtonPanel: FC = () => {
+  const { mobileSidebarOpened, setMobileSidebarOpened } = useEditorStore(
+    useShallow((state) => ({
+      mobileSidebarOpened: state.mobileSidebarOpened,
+      setMobileSidebarOpened: state.setMobileSidebarOpened,
+    })),
+  )
+
+  return (
+    <div className="fixed bottom-4 right-4 flex flex-col gap-2 xs:hidden">
+      <button
+        className="rounded-lg bg-black p-2"
+        onClick={() => setMobileSidebarOpened(true)}
+      >
+        <LuPanelRightOpen size={24} />
+      </button>
+    </div>
+  )
+}
+
+export default MobileBottomButtonPanel

--- a/packages/app/src/components/MobileBottomButtonPanel.tsx
+++ b/packages/app/src/components/MobileBottomButtonPanel.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react'
-
 import { LuPanelRightOpen } from 'react-icons/lu'
 import { useShallow } from 'zustand/shallow'
 

--- a/packages/app/src/components/MobileBottomButtonPanel.tsx
+++ b/packages/app/src/components/MobileBottomButtonPanel.tsx
@@ -2,6 +2,7 @@ import { LuPanelRightOpen } from 'react-icons/lu'
 import { useShallow } from 'zustand/shallow'
 
 import { useEditorStore } from '@/stores/editorStore'
+
 import FullscreenToggle from './FullscreenToggle'
 
 const MobileBottomButtonPanel: FC = () => {

--- a/packages/app/src/components/MobileDragHoldButton.tsx
+++ b/packages/app/src/components/MobileDragHoldButton.tsx
@@ -1,0 +1,57 @@
+import { FC, useState } from 'react'
+import {
+  LuSquareDashedMousePointer,
+  LuSquareMousePointer,
+} from 'react-icons/lu'
+import { useShallow } from 'zustand/shallow'
+
+import { useEditorStore } from '@/stores/editorStore'
+import { cn } from '@/utils'
+
+import FloatingButton from './FloatingButton'
+
+const MobileDragHoldButton: FC = () => {
+  const [alwaysDragMode, setAlwaysDragMode] = useState(false)
+  const [pointerDownTime, setPointerDownTime] = useState(Date.now())
+
+  const { mobileDragHoldButtonPressed, setMobileDragHoldButtonPressed } =
+    useEditorStore(
+      useShallow((state) => ({
+        mobileDragHoldButtonPressed: state.mobileDragHoldButtonPressed,
+        setMobileDragHoldButtonPressed: state.setMobileDragHoldButtonPressed,
+      })),
+    )
+
+  return (
+    <FloatingButton
+      className={cn(
+        'xs:hidden',
+        !alwaysDragMode && mobileDragHoldButtonPressed && 'bg-gray-800',
+      )}
+      active={alwaysDragMode}
+      onPointerDown={() => {
+        setPointerDownTime(Date.now())
+        setMobileDragHoldButtonPressed(true)
+      }}
+      onPointerLeave={() => {
+        setMobileDragHoldButtonPressed(false)
+        if (Date.now() - pointerDownTime <= 150) {
+          // 짧게 눌렀다 뗀 경우 모드 변경
+          setAlwaysDragMode((mode) => {
+            const newMode = !mode
+            setMobileDragHoldButtonPressed(newMode)
+            return newMode
+          })
+        }
+      }}
+    >
+      {alwaysDragMode ? (
+        <LuSquareMousePointer size={24} />
+      ) : (
+        <LuSquareDashedMousePointer size={24} />
+      )}
+    </FloatingButton>
+  )
+}
+
+export default MobileDragHoldButton

--- a/packages/app/src/components/Perf.tsx
+++ b/packages/app/src/components/Perf.tsx
@@ -1,0 +1,20 @@
+import { invalidate, useFrame } from '@react-three/fiber'
+import { Perf as R3FPerf } from 'r3f-perf'
+import { FC, useRef } from 'react'
+
+const Perf: FC = () => {
+  const count = useRef(0)
+
+  // r3f-perf가 초기화될 때 렌더링중이 아닐 경우 정상적으로 초기화되지 않으므로
+  // 초기화되는 동안만 연속으로 렌더링시키기
+  useFrame(() => {
+    if (count.current < 30) {
+      invalidate()
+      count.current++
+    }
+  })
+
+  return <R3FPerf position="bottom-left" style={{ zIndex: 10 }} />
+}
+
+export default Perf

--- a/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogTitle,
 } from '@headlessui/react'
 import { FC, useEffect, useState } from 'react'
+import { LuX } from 'react-icons/lu'
 import useSWRImmutable from 'swr/immutable'
 import { useShallow } from 'zustand/shallow'
 
@@ -50,16 +51,19 @@ const BlockDisplaySelectDialog: FC = () => {
     <Dialog open={isOpen} onClose={closeDialog} className="relative z-50">
       <DialogBackdrop
         transition
-        className="fixed inset-0 backdrop-blur-sm duration-200 ease-out data-[closed]:opacity-0"
+        className="fixed inset-0 duration-200 ease-out data-[closed]:opacity-0 xs:backdrop-blur-sm"
       />
 
-      <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+      <div className="fixed inset-0 flex w-screen items-center justify-center xs:p-4">
         <DialogPanel
           transition
-          className="flex h-[75vh] w-full max-w-screen-md select-none flex-col gap-2 rounded-xl bg-neutral-800 p-4 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0"
+          className="flex h-full w-full max-w-screen-md select-none flex-col gap-2 bg-neutral-800 p-4 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0 xs:h-[75vh] xs:rounded-xl"
         >
-          <DialogTitle className="text-2xl font-bold">
-            Add Block Display
+          <DialogTitle className="flex flex-row items-center">
+            <span className="grow text-2xl font-bold">Add Block Display</span>
+            <button onClick={closeDialog}>
+              <LuX size={24} />
+            </button>
           </DialogTitle>
 
           <div className="flex flex-row items-center gap-4">

--- a/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
@@ -1,9 +1,3 @@
-import {
-  Dialog,
-  DialogBackdrop,
-  DialogPanel,
-  DialogTitle,
-} from '@headlessui/react'
 import { FC, useEffect, useState } from 'react'
 import { LuX } from 'react-icons/lu'
 import useSWRImmutable from 'swr/immutable'
@@ -13,6 +7,8 @@ import fetcher from '@/fetcher'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
 import { CDNBlocksListResponse } from '@/types'
+
+import Dialog from './Dialog'
 
 const BlockDisplaySelectDialog: FC = () => {
   const [firstOpened, setFirstOpened] = useState(false)
@@ -48,49 +44,35 @@ const BlockDisplaySelectDialog: FC = () => {
   const searchResult = blocks.filter((block) => block.includes(searchQuery))
 
   return (
-    <Dialog open={isOpen} onClose={closeDialog} className="relative z-50">
-      <DialogBackdrop
-        transition
-        className="fixed inset-0 duration-200 ease-out data-[closed]:opacity-0 xs:backdrop-blur-sm"
-      />
+    <Dialog
+      title="Add Block Display"
+      open={isOpen}
+      onClose={closeDialog}
+      className="relative z-50"
+    >
+      <div className="flex flex-row items-center gap-4">
+        <span>Search</span>
+        <input
+          type="text"
+          className="grow rounded px-2 py-1 text-sm outline-none"
+          value={searchQuery}
+          onChange={(evt) => setSearchQuery(evt.target.value)}
+        />
+      </div>
 
-      <div className="fixed inset-0 flex w-screen items-center justify-center xs:p-4">
-        <DialogPanel
-          transition
-          className="flex h-full w-full max-w-screen-md select-none flex-col gap-2 bg-neutral-800 p-4 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0 xs:h-[75vh] xs:rounded-xl"
-        >
-          <DialogTitle className="flex flex-row items-center">
-            <span className="grow text-2xl font-bold">Add Block Display</span>
-            <button onClick={closeDialog}>
-              <LuX size={24} />
-            </button>
-          </DialogTitle>
-
-          <div className="flex flex-row items-center gap-4">
-            <span>Search</span>
-            <input
-              type="text"
-              className="grow rounded px-2 py-1 text-sm outline-none"
-              value={searchQuery}
-              onChange={(evt) => setSearchQuery(evt.target.value)}
-            />
-          </div>
-
-          <div className="flex h-full flex-col gap-1 overflow-auto rounded-lg p-1">
-            {searchResult.map((block) => (
-              <button
-                key={block}
-                className="rounded-lg bg-neutral-700 p-1 text-center text-xs transition duration-150 hover:bg-neutral-700/50"
-                onClick={() => {
-                  createNewEntity('block', block)
-                  setOpenedDialog(null)
-                }}
-              >
-                {block}
-              </button>
-            ))}
-          </div>
-        </DialogPanel>
+      <div className="flex h-full flex-col gap-1 overflow-auto rounded-lg p-1">
+        {searchResult.map((block) => (
+          <button
+            key={block}
+            className="rounded-lg bg-neutral-700 p-1 text-center text-xs transition duration-150 hover:bg-neutral-700/50"
+            onClick={() => {
+              createNewEntity('block', block)
+              setOpenedDialog(null)
+            }}
+          >
+            {block}
+          </button>
+        ))}
       </div>
     </Dialog>
   )

--- a/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
@@ -1,5 +1,4 @@
 import { FC, useEffect, useState } from 'react'
-import { LuX } from 'react-icons/lu'
 import useSWRImmutable from 'swr/immutable'
 import { useShallow } from 'zustand/shallow'
 

--- a/packages/app/src/components/dialog/Dialog.tsx
+++ b/packages/app/src/components/dialog/Dialog.tsx
@@ -27,7 +27,7 @@ const Dialog: FC<DialogProps> = ({
   return (
     <OriginalDialog
       open={open}
-      onClose={onClose}
+      onClose={() => onClose?.()}
       className={cn('relative z-50', className)}
     >
       <DialogBackdrop

--- a/packages/app/src/components/dialog/Dialog.tsx
+++ b/packages/app/src/components/dialog/Dialog.tsx
@@ -1,0 +1,57 @@
+import {
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+  Dialog as OriginalDialog,
+} from '@headlessui/react'
+import { FC, ReactNode } from 'react'
+import { LuX } from 'react-icons/lu'
+
+import { cn } from '@/utils'
+
+type DialogProps = {
+  open: boolean
+  onClose?: () => void
+  className?: string
+  title?: string
+  children?: ReactNode
+}
+
+const Dialog: FC<DialogProps> = ({
+  open,
+  onClose,
+  className,
+  title,
+  children,
+}) => {
+  return (
+    <OriginalDialog
+      open={open}
+      onClose={onClose}
+      className={cn('relative z-50', className)}
+    >
+      <DialogBackdrop
+        transition
+        className="fixed inset-0 duration-200 ease-out data-[closed]:opacity-0 xs:backdrop-blur-sm"
+      />
+
+      <div className="fixed inset-0 flex w-screen items-center justify-center xs:p-4">
+        <DialogPanel
+          transition
+          className="flex h-full w-full max-w-screen-md select-none flex-col gap-2 bg-neutral-800 p-4 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0 xs:h-[75vh] xs:rounded-xl"
+        >
+          <DialogTitle className="flex flex-row items-center">
+            <span className="grow text-2xl font-bold">{title}</span>
+            <button onClick={onClose}>
+              <LuX size={24} />
+            </button>
+          </DialogTitle>
+
+          {children}
+        </DialogPanel>
+      </div>
+    </OriginalDialog>
+  )
+}
+
+export default Dialog

--- a/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
+++ b/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
@@ -1,6 +1,6 @@
 import { useDebouncedEffect } from '@react-hookz/web'
 import { FC, JSX, useEffect, useState } from 'react'
-import { LuCopy, LuCopyCheck, LuX } from 'react-icons/lu'
+import { LuCopy, LuCopyCheck } from 'react-icons/lu'
 import { useShallow } from 'zustand/shallow'
 
 import { getLogger } from '@/services/loggerService'
@@ -121,8 +121,6 @@ const ExportToMinecraftDialog: FC = () => {
       entities: state.entities,
     })),
   )
-
-  const closeDialog = () => setOpenedDialog(null)
 
   const [baseTag, setBaseTag] = useState('')
   const [nbtDataGenerated, setNbtDataGenerated] = useState(false)

--- a/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
+++ b/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
@@ -6,7 +6,7 @@ import {
 } from '@headlessui/react'
 import { useDebouncedEffect } from '@react-hookz/web'
 import { FC, JSX, useEffect, useState } from 'react'
-import { LuCopy, LuCopyCheck } from 'react-icons/lu'
+import { LuCopy, LuCopyCheck, LuX } from 'react-icons/lu'
 import { useShallow } from 'zustand/shallow'
 
 import { getLogger } from '@/services/loggerService'
@@ -82,7 +82,7 @@ const TagValidatorInput: FC<TagValidatorInputProps> = ({ onChange }) => {
   const [hasValidationErrors, setHasValidationErrors] = useState(false)
 
   return (
-    <div className="flex flex-row items-center gap-2">
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
       <span>Base Tag</span>
       <input
         className="rounded p-1 text-sm outline-none"
@@ -125,6 +125,8 @@ const ExportToMinecraftDialog: FC = () => {
       entities: state.entities,
     })),
   )
+
+  const closeDialog = () => setOpenedDialog(null)
 
   const [baseTag, setBaseTag] = useState('')
   const [nbtDataGenerated, setNbtDataGenerated] = useState(false)
@@ -224,16 +226,22 @@ const ExportToMinecraftDialog: FC = () => {
     >
       <DialogBackdrop
         transition
-        className="fixed inset-0 backdrop-blur-sm duration-200 ease-out data-[closed]:opacity-0"
+        className="fixed inset-0 duration-200 ease-out data-[closed]:opacity-0 xs:backdrop-blur-sm"
       />
 
-      <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+      <div className="fixed inset-0 flex w-screen items-center justify-center xs:p-4">
         <DialogPanel
           transition
-          className="flex max-h-[90vh] w-full max-w-screen-md select-none flex-col rounded-xl bg-neutral-800 p-4 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0"
+          className="flex h-full w-full max-w-screen-md select-none flex-col bg-neutral-800 p-4 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0 xs:max-h-[90vh] xs:rounded-xl"
         >
-          <DialogTitle className="text-2xl font-bold">
-            Export to Minecraft
+          <DialogTitle className="flex flex-row items-center">
+            <span className="grow text-2xl font-bold">
+              Export to Minecraft{' '}
+            </span>{' '}
+            <button onClick={closeDialog}>
+              {' '}
+              <LuX size={24} />{' '}
+            </button>
           </DialogTitle>
 
           <div className="mt-2 rounded-lg bg-neutral-700 p-2">

--- a/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
+++ b/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
@@ -1,9 +1,3 @@
-import {
-  Dialog,
-  DialogBackdrop,
-  DialogPanel,
-  DialogTitle,
-} from '@headlessui/react'
 import { useDebouncedEffect } from '@react-hookz/web'
 import { FC, JSX, useEffect, useState } from 'react'
 import { LuCopy, LuCopyCheck, LuX } from 'react-icons/lu'
@@ -14,6 +8,8 @@ import { useDialogStore } from '@/stores/dialogStore'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
 import { useEntityRefStore } from '@/stores/entityRefStore'
 import { cn } from '@/utils'
+
+import Dialog from './Dialog'
 
 const logger = getLogger('ExportToMinecraftDialog')
 
@@ -220,73 +216,52 @@ const ExportToMinecraftDialog: FC = () => {
 
   return (
     <Dialog
+      title="Export to Minecraft"
       open={isOpen}
       onClose={() => setOpenedDialog(null)}
       className="relative z-50"
     >
-      <DialogBackdrop
-        transition
-        className="fixed inset-0 duration-200 ease-out data-[closed]:opacity-0 xs:backdrop-blur-sm"
-      />
+      <div className="mt-2 rounded-lg bg-neutral-700 p-2">
+        <TagValidatorInput onChange={setBaseTag} />
+      </div>
 
-      <div className="fixed inset-0 flex w-screen items-center justify-center xs:p-4">
-        <DialogPanel
-          transition
-          className="flex h-full w-full max-w-screen-md select-none flex-col bg-neutral-800 p-4 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0 xs:max-h-[90vh] xs:rounded-xl"
-        >
-          <DialogTitle className="flex flex-row items-center">
-            <span className="grow text-2xl font-bold">
-              Export to Minecraft{' '}
-            </span>{' '}
-            <button onClick={closeDialog}>
-              {' '}
-              <LuX size={24} />{' '}
-            </button>
-          </DialogTitle>
+      <hr className="my-2 border-gray-600" />
 
-          <div className="mt-2 rounded-lg bg-neutral-700 p-2">
-            <TagValidatorInput onChange={setBaseTag} />
-          </div>
-
-          <hr className="my-2 border-gray-600" />
-
-          <div className="overflow-y-auto">
-            {nbtStrings.map((nbt, idx) => {
-              const summonCommand = `/summon block_display ~ ~ ~ ${nbt}`
-              return (
-                <div key={idx}>
-                  <div className="flex flex-row items-center">
-                    <span className="grow">Summon command {idx + 1}</span>
-                    <CopyButton valueToCopy={summonCommand} />
-                  </div>
-                  <textarea
-                    className="h-24 w-full resize-none break-all rounded-lg p-2 outline-none"
-                    readOnly
-                    value={summonCommand}
-                    onFocus={(evt) => {
-                      evt.target.select()
-                    }}
-                  />
-                </div>
-              )
-            })}
-
-            <div>
+      <div className="overflow-y-auto">
+        {nbtStrings.map((nbt, idx) => {
+          const summonCommand = `/summon block_display ~ ~ ~ ${nbt}`
+          return (
+            <div key={idx}>
               <div className="flex flex-row items-center">
-                <span className="grow">Remove command</span>
-                <CopyButton valueToCopy={removeCommand} />
+                <span className="grow">Summon command {idx + 1}</span>
+                <CopyButton valueToCopy={summonCommand} />
               </div>
               <textarea
-                className="h-10 w-full resize-none break-all rounded-lg p-2 outline-none"
+                className="h-24 w-full resize-none break-all rounded-lg p-2 outline-none"
                 readOnly
-                value={removeCommand}
+                value={summonCommand}
                 onFocus={(evt) => {
                   evt.target.select()
                 }}
               />
             </div>
+          )
+        })}
+
+        <div>
+          <div className="flex flex-row items-center">
+            <span className="grow">Remove command</span>
+            <CopyButton valueToCopy={removeCommand} />
           </div>
-        </DialogPanel>
+          <textarea
+            className="h-10 w-full resize-none break-all rounded-lg p-2 outline-none"
+            readOnly
+            value={removeCommand}
+            onFocus={(evt) => {
+              evt.target.select()
+            }}
+          />
+        </div>
       </div>
     </Dialog>
   )

--- a/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogTitle,
 } from '@headlessui/react'
 import { FC, useEffect, useState } from 'react'
+import { LuX } from 'react-icons/lu'
 import useSWRImmutable from 'swr/immutable'
 import { useShallow } from 'zustand/shallow'
 
@@ -51,16 +52,19 @@ const ItemDisplaySelectDialog: FC = () => {
     <Dialog open={isOpen} onClose={closeDialog} className="relative z-50">
       <DialogBackdrop
         transition
-        className="fixed inset-0 backdrop-blur-sm duration-200 ease-out data-[closed]:opacity-0"
+        className="fixed inset-0 duration-200 ease-out data-[closed]:opacity-0 xs:backdrop-blur-sm"
       />
 
-      <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+      <div className="fixed inset-0 flex w-screen items-center justify-center xs:p-4">
         <DialogPanel
           transition
-          className="flex h-[75vh] w-full max-w-screen-md select-none flex-col gap-2 rounded-xl bg-neutral-800 p-4 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0"
+          className="flex h-full w-full max-w-screen-md select-none flex-col gap-2 rounded-xl bg-neutral-800 p-4 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0 xs:h-[75vh]"
         >
-          <DialogTitle className="text-2xl font-bold">
-            Add Item Display
+          <DialogTitle className="flex flex-row items-center">
+            <span className="grow text-2xl font-bold"> Add Item Display</span>{' '}
+            <button onClick={closeDialog}>
+              <LuX size={24} />
+            </button>
           </DialogTitle>
 
           <div className="flex flex-row items-center gap-4">

--- a/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
@@ -1,9 +1,3 @@
-import {
-  Dialog,
-  DialogBackdrop,
-  DialogPanel,
-  DialogTitle,
-} from '@headlessui/react'
 import { FC, useEffect, useState } from 'react'
 import { LuX } from 'react-icons/lu'
 import useSWRImmutable from 'swr/immutable'
@@ -13,6 +7,8 @@ import fetcher from '@/fetcher'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
 import { CDNItemsListResponse } from '@/types'
+
+import Dialog from './Dialog'
 
 const ItemDisplaySelectDialog: FC = () => {
   const [firstOpened, setFirstOpened] = useState(false)
@@ -49,49 +45,35 @@ const ItemDisplaySelectDialog: FC = () => {
   const searchResult = items.filter((item) => item.includes(searchQuery))
 
   return (
-    <Dialog open={isOpen} onClose={closeDialog} className="relative z-50">
-      <DialogBackdrop
-        transition
-        className="fixed inset-0 duration-200 ease-out data-[closed]:opacity-0 xs:backdrop-blur-sm"
-      />
+    <Dialog
+      title="Add Item Display"
+      open={isOpen}
+      onClose={closeDialog}
+      className="relative z-50"
+    >
+      <div className="flex flex-row items-center gap-4">
+        <span>Search</span>
+        <input
+          type="text"
+          className="grow rounded px-2 py-1 text-sm outline-none"
+          value={searchQuery}
+          onChange={(evt) => setSearchQuery(evt.target.value)}
+        />
+      </div>
 
-      <div className="fixed inset-0 flex w-screen items-center justify-center xs:p-4">
-        <DialogPanel
-          transition
-          className="flex h-full w-full max-w-screen-md select-none flex-col gap-2 rounded-xl bg-neutral-800 p-4 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0 xs:h-[75vh]"
-        >
-          <DialogTitle className="flex flex-row items-center">
-            <span className="grow text-2xl font-bold"> Add Item Display</span>{' '}
-            <button onClick={closeDialog}>
-              <LuX size={24} />
-            </button>
-          </DialogTitle>
-
-          <div className="flex flex-row items-center gap-4">
-            <span>Search</span>
-            <input
-              type="text"
-              className="grow rounded px-2 py-1 text-sm outline-none"
-              value={searchQuery}
-              onChange={(evt) => setSearchQuery(evt.target.value)}
-            />
-          </div>
-
-          <div className="flex h-full flex-col gap-1 overflow-auto rounded-lg p-1">
-            {searchResult.map((item) => (
-              <button
-                key={item}
-                className="rounded-lg bg-neutral-700 p-1 text-center text-xs transition duration-150 hover:bg-neutral-700/50"
-                onClick={() => {
-                  createNewEntity('item', item)
-                  setOpenedDialog(null)
-                }}
-              >
-                {item}
-              </button>
-            ))}
-          </div>
-        </DialogPanel>
+      <div className="flex h-full flex-col gap-1 overflow-auto rounded-lg p-1">
+        {searchResult.map((item) => (
+          <button
+            key={item}
+            className="rounded-lg bg-neutral-700 p-1 text-center text-xs transition duration-150 hover:bg-neutral-700/50"
+            onClick={() => {
+              createNewEntity('item', item)
+              setOpenedDialog(null)
+            }}
+          >
+            {item}
+          </button>
+        ))}
       </div>
     </Dialog>
   )

--- a/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
@@ -1,5 +1,4 @@
 import { FC, useEffect, useState } from 'react'
-import { LuX } from 'react-icons/lu'
 import useSWRImmutable from 'swr/immutable'
 import { useShallow } from 'zustand/shallow'
 

--- a/packages/app/src/components/dialog/SettingsDialog.tsx
+++ b/packages/app/src/components/dialog/SettingsDialog.tsx
@@ -36,8 +36,9 @@ const SettingsDialog: FC = () => {
       onClose={closeDialog}
       className="relative z-50"
     >
-      <div className="flex h-full w-full flex-row">
-        <div className="w-[30%] p-4 border-r-2 border-neutral-700">
+      <div className="flex h-full w-full flex-col xs:flex-row">
+        {/* Desktop - left side settings submenu list */}
+        <div className="hidden w-[30%] border-r-2 border-neutral-700 p-4 xs:block">
           <div className="mt-2 flex flex-col gap-1">
             <button
               className={cn(
@@ -74,8 +75,20 @@ const SettingsDialog: FC = () => {
             </button>
           </div>
         </div>
+        {/* Mobile - submenu <select> element on top */}
+        <div className="xs:hidden">
+          <select
+            className="w-full rounded bg-neutral-900 p-2"
+            value={selectedPage}
+            onChange={(evt) => setSelectedPage(evt.target.value)}
+          >
+            <option value="hotkeys">Hotkeys</option>
+            <option value="programInfo">Program Info</option>
+            <option value="test">test</option>
+          </select>
+        </div>
 
-        <div className="h-full w-full p-6">
+        <div className="h-full w-full py-4 xs:px-4">
           {/* Hotkeys */}
           {selectedPage === 'hotkeys' && (
             <div>
@@ -188,7 +201,7 @@ const SettingsDialog: FC = () => {
                 </label>
                 <select
                   id="settings_test_minloglevel"
-                  className="flex-none rounded bg-neutral-800 px-2 py-1"
+                  className="flex-none rounded bg-neutral-900 px-2 py-1"
                   value={settings.minLogLevel}
                   onChange={(evt) => {
                     setSettings({

--- a/packages/app/src/components/dialog/SettingsDialog.tsx
+++ b/packages/app/src/components/dialog/SettingsDialog.tsx
@@ -2,8 +2,6 @@ import { FC, useState } from 'react'
 import { useShallow } from 'zustand/shallow'
 
 import { useDialogStore } from '@/stores/dialogStore'
-import { useEditorStore } from '@/stores/editorStore'
-import { LogLevel } from '@/types'
 import { cn } from '@/utils'
 
 import Dialog from './Dialog'
@@ -19,12 +17,6 @@ const SettingsDialog: FC = () => {
     useShallow((state) => ({
       isOpen: state.openedDialog === 'settings',
       setOpenedDialog: state.setOpenedDialog,
-    })),
-  )
-  const { settings, setSettings } = useEditorStore(
-    useShallow((state) => ({
-      settings: state.settings,
-      setSettings: state.setSettings,
     })),
   )
 
@@ -95,7 +87,7 @@ const SettingsDialog: FC = () => {
           <select
             className="w-full rounded bg-neutral-900 p-2"
             value={selectedPage}
-            onChange={(evt) => setSelectedPage(evt.target.value)}
+            onChange={(evt) => setSelectedPage(evt.target.value as SettingsPageType)}
           >
             <option value="performance">Performance</option>
             <option value="hotkeys">Hotkeys</option>

--- a/packages/app/src/components/dialog/SettingsDialog.tsx
+++ b/packages/app/src/components/dialog/SettingsDialog.tsx
@@ -9,9 +9,10 @@ import { cn } from '@/utils'
 import Dialog from './Dialog'
 import DebugOptionsPage from './settings/DebugOptionsPage'
 import HotkeysPage from './settings/HotkeysPage'
+import PerformancePage from './settings/PerformancePage'
 import ProgramInfoPage from './settings/ProgramInfoPage'
 
-type SettingsPageType = 'hotkeys' | 'programInfo' | 'debug'
+type SettingsPageType = 'performance' | 'hotkeys' | 'programInfo' | 'debug'
 
 const SettingsDialog: FC = () => {
   const { isOpen, setOpenedDialog } = useDialogStore(
@@ -43,6 +44,17 @@ const SettingsDialog: FC = () => {
         {/* Desktop - left side settings submenu list */}
         <div className="hidden w-[30%] border-r-2 border-neutral-700 p-4 xs:block">
           <div className="mt-2 flex flex-col gap-1">
+            <button
+              className={cn(
+                'w-full rounded px-2 py-1 text-start text-sm transition duration-150',
+                selectedPage === 'performance'
+                  ? 'bg-neutral-700'
+                  : 'hover:bg-neutral-700/50',
+              )}
+              onClick={() => setSelectedPage('performance')}
+            >
+              Performance
+            </button>
             <button
               className={cn(
                 'w-full rounded px-2 py-1 text-start text-sm transition duration-150',
@@ -85,6 +97,7 @@ const SettingsDialog: FC = () => {
             value={selectedPage}
             onChange={(evt) => setSelectedPage(evt.target.value)}
           >
+            <option value="performance">Performance</option>
             <option value="hotkeys">Hotkeys</option>
             <option value="programInfo">Program Info</option>
             <option value="debug">Debug Options</option>
@@ -92,6 +105,9 @@ const SettingsDialog: FC = () => {
         </div>
 
         <div className="h-full w-full py-4 xs:px-4">
+          {/* Hotkeys */}
+          {selectedPage === 'performance' && <PerformancePage />}
+
           {/* Hotkeys */}
           {selectedPage === 'hotkeys' && <HotkeysPage />}
 

--- a/packages/app/src/components/dialog/SettingsDialog.tsx
+++ b/packages/app/src/components/dialog/SettingsDialog.tsx
@@ -1,9 +1,3 @@
-import {
-  Dialog,
-  DialogBackdrop,
-  DialogPanel,
-  DialogTitle,
-} from '@headlessui/react'
 import { FC, useState } from 'react'
 import { useShallow } from 'zustand/shallow'
 
@@ -11,6 +5,8 @@ import { useDialogStore } from '@/stores/dialogStore'
 import { useEditorStore } from '@/stores/editorStore'
 import { LogLevel } from '@/types'
 import { cn } from '@/utils'
+
+import Dialog from './Dialog'
 
 type SettingsPageType = 'hotkeys' | 'programInfo' | 'test'
 
@@ -34,196 +30,181 @@ const SettingsDialog: FC = () => {
   const closeDialog = () => setOpenedDialog(null)
 
   return (
-    <Dialog open={isOpen} onClose={closeDialog} className="relative z-50">
-      <DialogBackdrop
-        transition
-        className="fixed inset-0 backdrop-blur-sm duration-200 ease-out data-[closed]:opacity-0"
-      />
+    <Dialog
+      title="Settings"
+      open={isOpen}
+      onClose={closeDialog}
+      className="relative z-50"
+    >
+      <div className="flex h-full w-full flex-row">
+        <div className="w-[30%] p-4 border-r-2 border-neutral-700">
+          <div className="mt-2 flex flex-col gap-1">
+            <button
+              className={cn(
+                'w-full rounded px-2 py-1 text-start text-sm transition duration-150',
+                selectedPage === 'hotkeys'
+                  ? 'bg-neutral-700'
+                  : 'hover:bg-neutral-700/50',
+              )}
+              onClick={() => setSelectedPage('hotkeys')}
+            >
+              Hotkeys
+            </button>
+            <button
+              className={cn(
+                'w-full rounded px-2 py-1 text-start text-sm transition duration-150',
+                selectedPage === 'programInfo'
+                  ? 'bg-neutral-700'
+                  : 'hover:bg-neutral-700/50',
+              )}
+              onClick={() => setSelectedPage('programInfo')}
+            >
+              Program Info
+            </button>
+            <button
+              className={cn(
+                'w-full rounded px-2 py-1 text-start text-sm transition duration-150',
+                selectedPage === 'test'
+                  ? 'bg-neutral-700'
+                  : 'hover:bg-neutral-700/50',
+              )}
+              onClick={() => setSelectedPage('test')}
+            >
+              test menu
+            </button>
+          </div>
+        </div>
 
-      <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
-        <DialogPanel
-          transition
-          className="flex h-full max-h-[80%] w-full max-w-screen-xl select-none flex-col gap-2 rounded-xl bg-neutral-800 duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0"
-        >
-          <div className="flex h-full w-full flex-row">
-            <div className="w-[30%] rounded-xl p-4">
-              <DialogTitle className="text-xl font-semibold">
-                Settings
-              </DialogTitle>
-              <div className="mt-2 flex flex-col gap-1">
-                <button
-                  className={cn(
-                    'w-full rounded px-2 py-1 text-start text-sm transition duration-150',
-                    selectedPage === 'hotkeys'
-                      ? 'bg-neutral-700'
-                      : 'hover:bg-neutral-700/50',
-                  )}
-                  onClick={() => setSelectedPage('hotkeys')}
-                >
-                  Hotkeys
-                </button>
-                <button
-                  className={cn(
-                    'w-full rounded px-2 py-1 text-start text-sm transition duration-150',
-                    selectedPage === 'programInfo'
-                      ? 'bg-neutral-700'
-                      : 'hover:bg-neutral-700/50',
-                  )}
-                  onClick={() => setSelectedPage('programInfo')}
-                >
-                  Program Info
-                </button>
-                <button
-                  className={cn(
-                    'w-full rounded px-2 py-1 text-start text-sm transition duration-150',
-                    selectedPage === 'test'
-                      ? 'bg-neutral-700'
-                      : 'hover:bg-neutral-700/50',
-                  )}
-                  onClick={() => setSelectedPage('test')}
-                >
-                  test menu
-                </button>
+        <div className="h-full w-full p-6">
+          {/* Hotkeys */}
+          {selectedPage === 'hotkeys' && (
+            <div>
+              <h3 className="text-xl font-bold">Hotkeys</h3>
+              <div className="mt-2 text-sm text-neutral-500">
+                *Changing hotkeys are not yet supported.
+              </div>
+              <div className="mt-2">
+                <div className="rounded bg-neutral-800 px-3 py-1 text-gray-400">
+                  General
+                </div>
+                <div className="flex flex-col">
+                  <div className="mt-1 flex flex-row items-center gap-2">
+                    <span className="grow px-3">Open from file</span>
+                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+                      Ctrl + O
+                    </div>
+                  </div>
+                  <div className="mt-1 flex flex-row items-center gap-2">
+                    <span className="grow px-3">Save to file</span>
+                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+                      Ctrl + S
+                    </div>
+                  </div>
+                  <div className="mt-1 flex flex-row items-center gap-2">
+                    <span className="grow px-3">Open Settings</span>
+                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+                      Ctrl + ,
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="mt-1">
+                <div className="rounded bg-neutral-800 px-3 py-1 text-gray-400">
+                  Editor
+                </div>
+                <div className="flex flex-col">
+                  <div className="mt-1 flex flex-row items-center gap-2">
+                    <span className="grow px-3">Translate mode</span>
+                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+                      T
+                    </div>
+                  </div>
+                  <div className="mt-1 flex flex-row items-center gap-2">
+                    <span className="grow px-3">Rotate mode</span>
+                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+                      R
+                    </div>
+                  </div>
+                  <div className="mt-1 flex flex-row items-center gap-2">
+                    <span className="grow px-3">Scale mode</span>
+                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+                      S
+                    </div>
+                  </div>
+                  <div className="mt-1 flex flex-row items-center gap-2">
+                    <span className="grow px-3">Group/Ungroup</span>
+                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+                      G
+                    </div>
+                  </div>
+                  <div className="mt-1 flex flex-row items-center gap-2">
+                    <span className="grow px-3">Delete Entity</span>
+                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+                      Delete
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
+          )}
 
-            <div className="h-full w-full rounded-xl bg-neutral-900/70 p-6">
-              {/* Hotkeys */}
-              {selectedPage === 'hotkeys' && (
-                <div>
-                  <h3 className="text-2xl font-bold">Hotkeys</h3>
-                  <div className="mt-2 text-sm text-neutral-500">
-                    *Changing hotkeys are not yet supported.
-                  </div>
-                  <div className="mt-2">
-                    <div className="rounded bg-neutral-800 px-3 py-1 text-gray-400">
-                      General
-                    </div>
-                    <div className="flex flex-col">
-                      <div className="mt-1 flex flex-row items-center gap-2">
-                        <span className="grow px-3">Open from file</span>
-                        <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                          Ctrl + O
-                        </div>
-                      </div>
-                      <div className="mt-1 flex flex-row items-center gap-2">
-                        <span className="grow px-3">Save to file</span>
-                        <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                          Ctrl + S
-                        </div>
-                      </div>
-                      <div className="mt-1 flex flex-row items-center gap-2">
-                        <span className="grow px-3">Open Settings</span>
-                        <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                          Ctrl + ,
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="mt-1">
-                    <div className="rounded bg-neutral-800 px-3 py-1 text-gray-400">
-                      Editor
-                    </div>
-                    <div className="flex flex-col">
-                      <div className="mt-1 flex flex-row items-center gap-2">
-                        <span className="grow px-3">Translate mode</span>
-                        <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                          T
-                        </div>
-                      </div>
-                      <div className="mt-1 flex flex-row items-center gap-2">
-                        <span className="grow px-3">Rotate mode</span>
-                        <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                          R
-                        </div>
-                      </div>
-                      <div className="mt-1 flex flex-row items-center gap-2">
-                        <span className="grow px-3">Scale mode</span>
-                        <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                          S
-                        </div>
-                      </div>
-                      <div className="mt-1 flex flex-row items-center gap-2">
-                        <span className="grow px-3">Group/Ungroup</span>
-                        <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                          G
-                        </div>
-                      </div>
-                      <div className="mt-1 flex flex-row items-center gap-2">
-                        <span className="grow px-3">Delete Entity</span>
-                        <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                          Delete
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
+          {/* Program Info */}
+          {selectedPage === 'programInfo' && (
+            <div>
+              <h3 className="text-xl font-bold">Display Entity Platform</h3>
+              <div>Graphical editor for Minecraft display entities</div>
+              <div className="mt-4 flex flex-row items-center gap-2">
+                <span>v{__VERSION__}</span>
+                <span className="font-mono">{__COMMIT_HASH__}</span>
+                {__IS_DEV__ && <span>(Development Build)</span>}
+              </div>
 
-              {/* Program Info */}
-              {selectedPage === 'programInfo' && (
-                <div>
-                  <h3 className="text-2xl font-bold">
-                    Display Entity Platform
-                  </h3>
-                  <div>Graphical editor for Minecraft display entities</div>
-                  <div className="mt-4 flex flex-row items-center gap-2">
-                    <span>v{__VERSION__}</span>
-                    <span className="font-mono">{__COMMIT_HASH__}</span>
-                    {__IS_DEV__ && <span>(Development Build)</span>}
-                  </div>
-
-                  {/* Disclaimer */}
-                  <div className="mt-4 text-sm text-neutral-500">
-                    This website or tool is not an official Minecraft product.
-                    Minecraft is a trademark of Mojang AB. All rights related to
-                    Minecraft and its intellectual property are owned by Mojang
-                    AB.
-                  </div>
-                </div>
-              )}
-
-              {/* test page */}
-              {selectedPage === 'test' && (
-                <div>
-                  <div className="flex flex-row items-center gap-2">
-                    <input
-                      type="checkbox"
-                      id="settings_test_testoption"
-                      checked={settings.testOption}
-                      onChange={(evt) => {
-                        setSettings({ testOption: evt.target.checked })
-                      }}
-                    />
-                    <label htmlFor="settings_test_testoption">
-                      Test Option
-                    </label>
-                  </div>
-                  <div className="flex flex-row items-center gap-2">
-                    <label htmlFor="settings_test_minloglevel">
-                      Minimum Log Level
-                    </label>
-                    <select
-                      id="settings_test_minloglevel"
-                      className="flex-none rounded bg-neutral-800 px-2 py-1"
-                      value={settings.minLogLevel}
-                      onChange={(evt) => {
-                        setSettings({
-                          minLogLevel: evt.target.value as LogLevel,
-                        })
-                      }}
-                    >
-                      <option>error</option>
-                      <option>warn</option>
-                      <option>info</option>
-                      <option>debug</option>
-                    </select>
-                  </div>
-                </div>
-              )}
+              {/* Disclaimer */}
+              <div className="mt-4 text-sm text-neutral-500">
+                This website or tool is not an official Minecraft product.
+                Minecraft is a trademark of Mojang AB. All rights related to
+                Minecraft and its intellectual property are owned by Mojang AB.
+              </div>
             </div>
-          </div>
-        </DialogPanel>
+          )}
+
+          {/* test page */}
+          {selectedPage === 'test' && (
+            <div>
+              <div className="flex flex-row items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="settings_test_testoption"
+                  checked={settings.testOption}
+                  onChange={(evt) => {
+                    setSettings({ testOption: evt.target.checked })
+                  }}
+                />
+                <label htmlFor="settings_test_testoption">Test Option</label>
+              </div>
+              <div className="flex flex-row items-center gap-2">
+                <label htmlFor="settings_test_minloglevel">
+                  Minimum Log Level
+                </label>
+                <select
+                  id="settings_test_minloglevel"
+                  className="flex-none rounded bg-neutral-800 px-2 py-1"
+                  value={settings.minLogLevel}
+                  onChange={(evt) => {
+                    setSettings({
+                      minLogLevel: evt.target.value as LogLevel,
+                    })
+                  }}
+                >
+                  <option>error</option>
+                  <option>warn</option>
+                  <option>info</option>
+                  <option>debug</option>
+                </select>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </Dialog>
   )

--- a/packages/app/src/components/dialog/SettingsDialog.tsx
+++ b/packages/app/src/components/dialog/SettingsDialog.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/utils'
 
 import Dialog from './Dialog'
 
-type SettingsPageType = 'hotkeys' | 'programInfo' | 'test'
+type SettingsPageType = 'hotkeys' | 'programInfo' | 'debug'
 
 const SettingsDialog: FC = () => {
   const { isOpen, setOpenedDialog } = useDialogStore(
@@ -65,13 +65,13 @@ const SettingsDialog: FC = () => {
             <button
               className={cn(
                 'w-full rounded px-2 py-1 text-start text-sm transition duration-150',
-                selectedPage === 'test'
+                selectedPage === 'debug'
                   ? 'bg-neutral-700'
                   : 'hover:bg-neutral-700/50',
               )}
-              onClick={() => setSelectedPage('test')}
+              onClick={() => setSelectedPage('debug')}
             >
-              test menu
+              Debug Options
             </button>
           </div>
         </div>
@@ -84,7 +84,7 @@ const SettingsDialog: FC = () => {
           >
             <option value="hotkeys">Hotkeys</option>
             <option value="programInfo">Program Info</option>
-            <option value="test">test</option>
+            <option value="debug">Debug Options</option>
           </select>
         </div>
 
@@ -181,31 +181,32 @@ const SettingsDialog: FC = () => {
             </div>
           )}
 
-          {/* test page */}
-          {selectedPage === 'test' && (
+          {/* Debug */}
+          {selectedPage === 'debug' && (
             <div>
-              <div className="flex flex-row items-center gap-2">
+              <h3 className="text-xl font-bold">Debug Options</h3>
+              <div className="mt-4 flex flex-row items-center gap-2">
                 <input
                   type="checkbox"
-                  id="settings_test_testoption"
-                  checked={settings.testOption}
+                  id="settings_debug_testoption"
+                  checked={settings.debug.testOption}
                   onChange={(evt) => {
-                    setSettings({ testOption: evt.target.checked })
+                    setSettings({ debug: { testOption: evt.target.checked } })
                   }}
                 />
-                <label htmlFor="settings_test_testoption">Test Option</label>
+                <label htmlFor="settings_debug_testoption">Test Option</label>
               </div>
               <div className="flex flex-row items-center gap-2">
-                <label htmlFor="settings_test_minloglevel">
+                <label htmlFor="settings_debug_minloglevel">
                   Minimum Log Level
                 </label>
                 <select
-                  id="settings_test_minloglevel"
+                  id="settings_debug_minloglevel"
                   className="flex-none rounded bg-neutral-900 px-2 py-1"
-                  value={settings.minLogLevel}
+                  value={settings.debug.minLogLevel}
                   onChange={(evt) => {
                     setSettings({
-                      minLogLevel: evt.target.value as LogLevel,
+                      debug: { minLogLevel: evt.target.value as LogLevel },
                     })
                   }}
                 >

--- a/packages/app/src/components/dialog/SettingsDialog.tsx
+++ b/packages/app/src/components/dialog/SettingsDialog.tsx
@@ -196,7 +196,7 @@ const SettingsDialog: FC = () => {
                 />
                 <label htmlFor="settings_debug_testoption">Test Option</label>
               </div>
-              <div className="flex flex-row items-center gap-2">
+              <div className="mt-4 flex flex-row items-center gap-2">
                 <label htmlFor="settings_debug_minloglevel">
                   Minimum Log Level
                 </label>
@@ -215,6 +215,21 @@ const SettingsDialog: FC = () => {
                   <option>info</option>
                   <option>debug</option>
                 </select>
+              </div>
+              <div className="mt-4 flex flex-row items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="settings_debug_perfMonitorEnabled"
+                  checked={settings.debug.perfMonitorEnabled}
+                  onChange={(evt) => {
+                    setSettings({
+                      debug: { perfMonitorEnabled: evt.target.checked },
+                    })
+                  }}
+                />
+                <label htmlFor="settings_debug_perfMonitorEnabled">
+                  Enable Performance Monitor
+                </label>
               </div>
             </div>
           )}

--- a/packages/app/src/components/dialog/SettingsDialog.tsx
+++ b/packages/app/src/components/dialog/SettingsDialog.tsx
@@ -191,7 +191,9 @@ const SettingsDialog: FC = () => {
                   id="settings_debug_testoption"
                   checked={settings.debug.testOption}
                   onChange={(evt) => {
-                    setSettings({ debug: { testOption: evt.target.checked } })
+                    setSettings({
+                      debug: { testOption: evt.target.checked },
+                    })
                   }}
                 />
                 <label htmlFor="settings_debug_testoption">Test Option</label>
@@ -229,6 +231,21 @@ const SettingsDialog: FC = () => {
                 />
                 <label htmlFor="settings_debug_perfMonitorEnabled">
                   Enable Performance Monitor
+                </label>
+              </div>
+              <div className="mt-4 flex flex-row items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="settings_debug_alertUncaughtError"
+                  checked={settings.debug.alertUncaughtError}
+                  onChange={(evt) => {
+                    setSettings({
+                      debug: { alertUncaughtError: evt.target.checked },
+                    })
+                  }}
+                />
+                <label htmlFor="settings_debug_alertUncaughtError">
+                  Notify uncaught errors with window.alert()
                 </label>
               </div>
             </div>

--- a/packages/app/src/components/dialog/SettingsDialog.tsx
+++ b/packages/app/src/components/dialog/SettingsDialog.tsx
@@ -87,7 +87,9 @@ const SettingsDialog: FC = () => {
           <select
             className="w-full rounded bg-neutral-900 p-2"
             value={selectedPage}
-            onChange={(evt) => setSelectedPage(evt.target.value as SettingsPageType)}
+            onChange={(evt) =>
+              setSelectedPage(evt.target.value as SettingsPageType)
+            }
           >
             <option value="performance">Performance</option>
             <option value="hotkeys">Hotkeys</option>

--- a/packages/app/src/components/dialog/SettingsDialog.tsx
+++ b/packages/app/src/components/dialog/SettingsDialog.tsx
@@ -7,6 +7,9 @@ import { LogLevel } from '@/types'
 import { cn } from '@/utils'
 
 import Dialog from './Dialog'
+import DebugOptionsPage from './settings/DebugOptionsPage'
+import HotkeysPage from './settings/HotkeysPage'
+import ProgramInfoPage from './settings/ProgramInfoPage'
 
 type SettingsPageType = 'hotkeys' | 'programInfo' | 'debug'
 
@@ -90,166 +93,13 @@ const SettingsDialog: FC = () => {
 
         <div className="h-full w-full py-4 xs:px-4">
           {/* Hotkeys */}
-          {selectedPage === 'hotkeys' && (
-            <div>
-              <h3 className="text-xl font-bold">Hotkeys</h3>
-              <div className="mt-2 text-sm text-neutral-500">
-                *Changing hotkeys are not yet supported.
-              </div>
-              <div className="mt-2">
-                <div className="rounded bg-neutral-800 px-3 py-1 text-gray-400">
-                  General
-                </div>
-                <div className="flex flex-col">
-                  <div className="mt-1 flex flex-row items-center gap-2">
-                    <span className="grow px-3">Open from file</span>
-                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                      Ctrl + O
-                    </div>
-                  </div>
-                  <div className="mt-1 flex flex-row items-center gap-2">
-                    <span className="grow px-3">Save to file</span>
-                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                      Ctrl + S
-                    </div>
-                  </div>
-                  <div className="mt-1 flex flex-row items-center gap-2">
-                    <span className="grow px-3">Open Settings</span>
-                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                      Ctrl + ,
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div className="mt-1">
-                <div className="rounded bg-neutral-800 px-3 py-1 text-gray-400">
-                  Editor
-                </div>
-                <div className="flex flex-col">
-                  <div className="mt-1 flex flex-row items-center gap-2">
-                    <span className="grow px-3">Translate mode</span>
-                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                      T
-                    </div>
-                  </div>
-                  <div className="mt-1 flex flex-row items-center gap-2">
-                    <span className="grow px-3">Rotate mode</span>
-                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                      R
-                    </div>
-                  </div>
-                  <div className="mt-1 flex flex-row items-center gap-2">
-                    <span className="grow px-3">Scale mode</span>
-                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                      S
-                    </div>
-                  </div>
-                  <div className="mt-1 flex flex-row items-center gap-2">
-                    <span className="grow px-3">Group/Ungroup</span>
-                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                      G
-                    </div>
-                  </div>
-                  <div className="mt-1 flex flex-row items-center gap-2">
-                    <span className="grow px-3">Delete Entity</span>
-                    <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
-                      Delete
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
+          {selectedPage === 'hotkeys' && <HotkeysPage />}
 
           {/* Program Info */}
-          {selectedPage === 'programInfo' && (
-            <div>
-              <h3 className="text-xl font-bold">Display Entity Platform</h3>
-              <div>Graphical editor for Minecraft display entities</div>
-              <div className="mt-4 flex flex-row items-center gap-2">
-                <span>v{__VERSION__}</span>
-                <span className="font-mono">{__COMMIT_HASH__}</span>
-                {__IS_DEV__ && <span>(Development Build)</span>}
-              </div>
-
-              {/* Disclaimer */}
-              <div className="mt-4 text-sm text-neutral-500">
-                This website or tool is not an official Minecraft product.
-                Minecraft is a trademark of Mojang AB. All rights related to
-                Minecraft and its intellectual property are owned by Mojang AB.
-              </div>
-            </div>
-          )}
+          {selectedPage === 'programInfo' && <ProgramInfoPage />}
 
           {/* Debug */}
-          {selectedPage === 'debug' && (
-            <div>
-              <h3 className="text-xl font-bold">Debug Options</h3>
-              <div className="mt-4 flex flex-row items-center gap-2">
-                <input
-                  type="checkbox"
-                  id="settings_debug_testoption"
-                  checked={settings.debug.testOption}
-                  onChange={(evt) => {
-                    setSettings({
-                      debug: { testOption: evt.target.checked },
-                    })
-                  }}
-                />
-                <label htmlFor="settings_debug_testoption">Test Option</label>
-              </div>
-              <div className="mt-4 flex flex-row items-center gap-2">
-                <label htmlFor="settings_debug_minloglevel">
-                  Minimum Log Level
-                </label>
-                <select
-                  id="settings_debug_minloglevel"
-                  className="flex-none rounded bg-neutral-900 px-2 py-1"
-                  value={settings.debug.minLogLevel}
-                  onChange={(evt) => {
-                    setSettings({
-                      debug: { minLogLevel: evt.target.value as LogLevel },
-                    })
-                  }}
-                >
-                  <option>error</option>
-                  <option>warn</option>
-                  <option>info</option>
-                  <option>debug</option>
-                </select>
-              </div>
-              <div className="mt-4 flex flex-row items-center gap-2">
-                <input
-                  type="checkbox"
-                  id="settings_debug_perfMonitorEnabled"
-                  checked={settings.debug.perfMonitorEnabled}
-                  onChange={(evt) => {
-                    setSettings({
-                      debug: { perfMonitorEnabled: evt.target.checked },
-                    })
-                  }}
-                />
-                <label htmlFor="settings_debug_perfMonitorEnabled">
-                  Enable Performance Monitor
-                </label>
-              </div>
-              <div className="mt-4 flex flex-row items-center gap-2">
-                <input
-                  type="checkbox"
-                  id="settings_debug_alertUncaughtError"
-                  checked={settings.debug.alertUncaughtError}
-                  onChange={(evt) => {
-                    setSettings({
-                      debug: { alertUncaughtError: evt.target.checked },
-                    })
-                  }}
-                />
-                <label htmlFor="settings_debug_alertUncaughtError">
-                  Notify uncaught errors with window.alert()
-                </label>
-              </div>
-            </div>
-          )}
+          {selectedPage === 'debug' && <DebugOptionsPage />}
         </div>
       </div>
     </Dialog>

--- a/packages/app/src/components/dialog/settings/DebugOptionsPage.tsx
+++ b/packages/app/src/components/dialog/settings/DebugOptionsPage.tsx
@@ -1,0 +1,84 @@
+import { FC } from 'react'
+import { useShallow } from 'zustand/shallow'
+
+import { useEditorStore } from '@/stores/editorStore'
+import { LogLevel } from '@/types'
+import { cn } from '@/utils'
+
+const DebugOptionsPage: FC = () => {
+  const { settings, setSettings } = useEditorStore(
+    useShallow((state) => ({
+      settings: state.settings,
+      setSettings: state.setSettings,
+    })),
+  )
+
+  return (
+    <>
+      <h3 className="text-xl font-bold">Debug Options</h3>
+      <div className="mt-4 flex flex-row items-center gap-2">
+        <input
+          type="checkbox"
+          id="settings_debug_testoption"
+          checked={settings.debug.testOption}
+          onChange={(evt) => {
+            setSettings({
+              debug: { testOption: evt.target.checked },
+            })
+          }}
+        />
+        <label htmlFor="settings_debug_testoption">Test Option</label>
+      </div>
+      <div className="mt-4 flex flex-row items-center gap-2">
+        <label htmlFor="settings_debug_minloglevel">Minimum Log Level</label>
+        <select
+          id="settings_debug_minloglevel"
+          className="flex-none rounded bg-neutral-900 px-2 py-1"
+          value={settings.debug.minLogLevel}
+          onChange={(evt) => {
+            setSettings({
+              debug: { minLogLevel: evt.target.value as LogLevel },
+            })
+          }}
+        >
+          <option>error</option>
+          <option>warn</option>
+          <option>info</option>
+          <option>debug</option>
+        </select>
+      </div>
+      <div className="mt-4 flex flex-row items-center gap-2">
+        <input
+          type="checkbox"
+          id="settings_debug_perfMonitorEnabled"
+          checked={settings.debug.perfMonitorEnabled}
+          onChange={(evt) => {
+            setSettings({
+              debug: { perfMonitorEnabled: evt.target.checked },
+            })
+          }}
+        />
+        <label htmlFor="settings_debug_perfMonitorEnabled">
+          Enable Performance Monitor
+        </label>
+      </div>
+      <div className="mt-4 flex flex-row items-center gap-2">
+        <input
+          type="checkbox"
+          id="settings_debug_alertUncaughtError"
+          checked={settings.debug.alertUncaughtError}
+          onChange={(evt) => {
+            setSettings({
+              debug: { alertUncaughtError: evt.target.checked },
+            })
+          }}
+        />
+        <label htmlFor="settings_debug_alertUncaughtError">
+          Notify uncaught errors with window.alert()
+        </label>
+      </div>
+    </>
+  )
+}
+
+export default DebugOptionsPage

--- a/packages/app/src/components/dialog/settings/DebugOptionsPage.tsx
+++ b/packages/app/src/components/dialog/settings/DebugOptionsPage.tsx
@@ -3,7 +3,6 @@ import { useShallow } from 'zustand/shallow'
 
 import { useEditorStore } from '@/stores/editorStore'
 import { LogLevel } from '@/types'
-import { cn } from '@/utils'
 
 const DebugOptionsPage: FC = () => {
   const { settings, setSettings } = useEditorStore(

--- a/packages/app/src/components/dialog/settings/HotkeysPage.tsx
+++ b/packages/app/src/components/dialog/settings/HotkeysPage.tsx
@@ -1,0 +1,76 @@
+import { FC } from 'react'
+
+const HotkeysPage: FC = () => {
+  return (
+    <>
+      <h3 className="text-xl font-bold">Hotkeys</h3>
+      <div className="mt-2 text-sm text-neutral-500">
+        *Changing hotkeys are not yet supported.
+      </div>
+      <div className="mt-2">
+        <div className="rounded bg-neutral-800 px-3 py-1 text-gray-400">
+          General
+        </div>
+        <div className="flex flex-col">
+          <div className="mt-1 flex flex-row items-center gap-2">
+            <span className="grow px-3">Open from file</span>
+            <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+              Ctrl + O
+            </div>
+          </div>
+          <div className="mt-1 flex flex-row items-center gap-2">
+            <span className="grow px-3">Save to file</span>
+            <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+              Ctrl + S
+            </div>
+          </div>
+          <div className="mt-1 flex flex-row items-center gap-2">
+            <span className="grow px-3">Open Settings</span>
+            <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+              Ctrl + ,
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="mt-1">
+        <div className="rounded bg-neutral-800 px-3 py-1 text-gray-400">
+          Editor
+        </div>
+        <div className="flex flex-col">
+          <div className="mt-1 flex flex-row items-center gap-2">
+            <span className="grow px-3">Translate mode</span>
+            <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+              T
+            </div>
+          </div>
+          <div className="mt-1 flex flex-row items-center gap-2">
+            <span className="grow px-3">Rotate mode</span>
+            <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+              R
+            </div>
+          </div>
+          <div className="mt-1 flex flex-row items-center gap-2">
+            <span className="grow px-3">Scale mode</span>
+            <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+              S
+            </div>
+          </div>
+          <div className="mt-1 flex flex-row items-center gap-2">
+            <span className="grow px-3">Group/Ungroup</span>
+            <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+              G
+            </div>
+          </div>
+          <div className="mt-1 flex flex-row items-center gap-2">
+            <span className="grow px-3">Delete Entity</span>
+            <div className="w-full max-w-[12rem] rounded bg-neutral-700/70 px-2 py-1">
+              Delete
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default HotkeysPage

--- a/packages/app/src/components/dialog/settings/PerformancePage.tsx
+++ b/packages/app/src/components/dialog/settings/PerformancePage.tsx
@@ -1,0 +1,38 @@
+import { FC } from 'react'
+import { useShallow } from 'zustand/shallow'
+
+import { useEditorStore } from '@/stores/editorStore'
+import { LogLevel } from '@/types'
+import { cn } from '@/utils'
+
+const PerformancePage: FC = () => {
+  const { settings, setSettings } = useEditorStore(
+    useShallow((state) => ({
+      settings: state.settings,
+      setSettings: state.setSettings,
+    })),
+  )
+
+  return (
+    <>
+      <h3 className="text-xl font-bold">Performance</h3>
+      <div className="mt-4 flex flex-row items-center gap-2">
+        <input
+          type="checkbox"
+          id="settings_performance_reducePixelRatio"
+          checked={settings.performance.reducePixelRatio}
+          onChange={(evt) => {
+            setSettings({
+              performance: { reducePixelRatio: evt.target.checked },
+            })
+          }}
+        />
+        <label htmlFor="settings_performance_reducePixelRatio">
+          Reduce Pixel Ratio to 1
+        </label>
+      </div>
+    </>
+  )
+}
+
+export default PerformancePage

--- a/packages/app/src/components/dialog/settings/PerformancePage.tsx
+++ b/packages/app/src/components/dialog/settings/PerformancePage.tsx
@@ -2,8 +2,6 @@ import { FC } from 'react'
 import { useShallow } from 'zustand/shallow'
 
 import { useEditorStore } from '@/stores/editorStore'
-import { LogLevel } from '@/types'
-import { cn } from '@/utils'
 
 const PerformancePage: FC = () => {
   const { settings, setSettings } = useEditorStore(

--- a/packages/app/src/components/dialog/settings/ProgramInfoPage.tsx
+++ b/packages/app/src/components/dialog/settings/ProgramInfoPage.tsx
@@ -1,0 +1,24 @@
+import { FC } from 'react'
+
+const ProgramInfoPage: FC = () => {
+  return (
+    <>
+      <h3 className="text-xl font-bold">Display Entity Platform</h3>
+      <div>Graphical editor for Minecraft display entities</div>
+      <div className="mt-4 flex flex-row items-center gap-2">
+        <span>v{__VERSION__}</span>
+        <span className="font-mono">{__COMMIT_HASH__}</span>
+        {__IS_DEV__ && <span>(Development Build)</span>}
+      </div>
+
+      {/* Disclaimer */}
+      <div className="mt-4 text-sm text-neutral-500">
+        This website or tool is not an official Minecraft product. Minecraft is
+        a trademark of Mojang AB. All rights related to Minecraft and its
+        intellectual property are owned by Mojang AB.
+      </div>
+    </>
+  )
+}
+
+export default ProgramInfoPage

--- a/packages/app/src/components/ui/DropdownMenu.tsx
+++ b/packages/app/src/components/ui/DropdownMenu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md bg-neutral-900 p-2 shadow-lg',
+      'z-50 min-w-[8rem] overflow-hidden rounded-md bg-neutral-900 p-2 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className,
     )}
     {...props}
@@ -67,7 +67,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         // 'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-neutral-900 p-1 shadow-md',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-10 min-w-[8rem] overflow-hidden rounded-md bg-neutral-900 p-1 shadow-md',
+        'z-10 min-w-[8rem] overflow-hidden rounded-md bg-neutral-900 p-1 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
         className,
       )}
       {...props}

--- a/packages/app/src/services/loggerService.ts
+++ b/packages/app/src/services/loggerService.ts
@@ -14,7 +14,9 @@ type LogFunction = ((logLevel: LogLevel, ...content: unknown[]) => void) & {
 export function getLogger(prefix: string) {
   const func: LogFunction = (logLevel, ...content) => {
     const {
-      settings: { debug: { minLogLevel } },
+      settings: {
+        debug: { minLogLevel },
+      },
     } = useEditorStore.getState()
 
     const logLevelIdx = logLevelOrder.findIndex((d) => d === logLevel)

--- a/packages/app/src/services/loggerService.ts
+++ b/packages/app/src/services/loggerService.ts
@@ -14,7 +14,7 @@ type LogFunction = ((logLevel: LogLevel, ...content: unknown[]) => void) & {
 export function getLogger(prefix: string) {
   const func: LogFunction = (logLevel, ...content) => {
     const {
-      settings: { minLogLevel },
+      settings: { debug: { minLogLevel } },
     } = useEditorStore.getState()
 
     const logLevelIdx = logLevelOrder.findIndex((d) => d === logLevel)

--- a/packages/app/src/stores/editorStore.ts
+++ b/packages/app/src/stores/editorStore.ts
@@ -31,6 +31,9 @@ type EditorState = {
   mode: EditorMode
   setMode: (newMode: EditorMode) => void
 
+  mobileSidebarOpened: boolean
+  setMobileSidebarOpened: (opened: boolean) => void
+
   usingTransformControl: boolean
   setUsingTransformControl: (value: boolean) => void
 
@@ -77,6 +80,12 @@ export const useEditorStore = create(
       setMode: (newMode) =>
         set((state) => {
           state.mode = newMode
+        }),
+
+      mobileSidebarOpened: false,
+      setMobileSidebarOpened: (opened) =>
+        set((state) => {
+          state.mobileSidebarOpened = opened
         }),
 
       usingTransformControl: false,

--- a/packages/app/src/stores/editorStore.ts
+++ b/packages/app/src/stores/editorStore.ts
@@ -51,6 +51,9 @@ type EditorState = {
   mobileSidebarOpened: boolean
   setMobileSidebarOpened: (opened: boolean) => void
 
+  mobileDragHoldButtonPressed: boolean
+  setMobileDragHoldButtonPressed: (pressed: boolean) => void
+
   usingTransformControl: boolean
   setUsingTransformControl: (value: boolean) => void
 
@@ -105,6 +108,12 @@ export const useEditorStore = create(
       setMobileSidebarOpened: (opened) =>
         set((state) => {
           state.mobileSidebarOpened = opened
+        }),
+
+      mobileDragHoldButtonPressed: false,
+      setMobileDragHoldButtonPressed: (pressed) =>
+        set((state) => {
+          state.mobileDragHoldButtonPressed = pressed
         }),
 
       usingTransformControl: false,

--- a/packages/app/src/stores/editorStore.ts
+++ b/packages/app/src/stores/editorStore.ts
@@ -28,6 +28,7 @@ const settingsSchema = z.object({
         >(['error', 'warn', 'info', 'debug'])
         .default('info'),
       perfMonitorEnabled: z.boolean().default(false),
+      alertUncaughtError: z.boolean().default(false),
     })
     .default({}),
 })
@@ -80,6 +81,8 @@ export const useEditorStore = create(
       testOption: false,
       minLogLevel: 'info',
     }
+    globalThis.__depl_alertUncaughtError =
+      initialSettings.debug.alertUncaughtError
 
     return {
       mode: 'translate',
@@ -143,6 +146,11 @@ export const useEditorStore = create(
       setSettings: (newSettings) =>
         set((state) => {
           merge(state.settings, newSettings)
+
+          if (newSettings.debug.alertUncaughtError != null) {
+            globalThis.__depl_alertUncaughtError =
+              newSettings.debug.alertUncaughtError
+          }
 
           try {
             window.localStorage.setItem(

--- a/packages/app/src/stores/editorStore.ts
+++ b/packages/app/src/stores/editorStore.ts
@@ -27,6 +27,7 @@ const settingsSchema = z.object({
           [LogLevel, ...LogLevel[]]
         >(['error', 'warn', 'info', 'debug'])
         .default('info'),
+      perfMonitorEnabled: z.boolean().default(false),
     })
     .default({}),
 })

--- a/packages/app/src/stores/editorStore.ts
+++ b/packages/app/src/stores/editorStore.ts
@@ -18,6 +18,11 @@ type TransformationData = {
 }
 
 const settingsSchema = z.object({
+  performance: z
+    .object({
+      reducePixelRatio: z.boolean().default(false),
+    })
+    .default({}),
   debug: z
     .object({
       testOption: z.boolean().default(false),
@@ -82,7 +87,7 @@ export const useEditorStore = create(
       minLogLevel: 'info',
     }
     globalThis.__depl_alertUncaughtError =
-      initialSettings.debug.alertUncaughtError
+      initialSettings?.debug?.alertUncaughtErro
 
     return {
       mode: 'translate',
@@ -147,7 +152,7 @@ export const useEditorStore = create(
         set((state) => {
           merge(state.settings, newSettings)
 
-          if (newSettings.debug.alertUncaughtError != null) {
+          if (newSettings?.debug?.alertUncaughtError != null) {
             globalThis.__depl_alertUncaughtError =
               newSettings.debug.alertUncaughtError
           }

--- a/packages/app/src/stores/editorStore.ts
+++ b/packages/app/src/stores/editorStore.ts
@@ -1,3 +1,4 @@
+import merge from 'lodash.merge'
 import { z } from 'zod'
 import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
@@ -17,13 +18,17 @@ type TransformationData = {
 }
 
 const settingsSchema = z.object({
-  testOption: z.boolean().default(false),
-  minLogLevel: z
-    .enum<
-      LogLevel,
-      [LogLevel, ...LogLevel[]]
-    >(['error', 'warn', 'info', 'debug'])
-    .default('info'),
+  debug: z
+    .object({
+      testOption: z.boolean().default(false),
+      minLogLevel: z
+        .enum<
+          LogLevel,
+          [LogLevel, ...LogLevel[]]
+        >(['error', 'warn', 'info', 'debug'])
+        .default('info'),
+    })
+    .default({}),
 })
 type Settings = z.infer<typeof settingsSchema>
 
@@ -136,7 +141,7 @@ export const useEditorStore = create(
       settings: initialSettings,
       setSettings: (newSettings) =>
         set((state) => {
-          state.settings = { ...state.settings, ...newSettings }
+          merge(state.settings, newSettings)
 
           try {
             window.localStorage.setItem(

--- a/packages/app/src/stores/editorStore.ts
+++ b/packages/app/src/stores/editorStore.ts
@@ -4,7 +4,12 @@ import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 
 import { getLogger } from '@/services/loggerService'
-import { DeepPartial, LogLevel, Number3Tuple, PartialNumber3Tuple } from '@/types'
+import {
+  DeepPartial,
+  LogLevel,
+  Number3Tuple,
+  PartialNumber3Tuple,
+} from '@/types'
 
 const logger = getLogger('editorStore')
 

--- a/packages/app/src/stores/editorStore.ts
+++ b/packages/app/src/stores/editorStore.ts
@@ -4,7 +4,7 @@ import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 
 import { getLogger } from '@/services/loggerService'
-import { LogLevel, Number3Tuple, PartialNumber3Tuple } from '@/types'
+import { DeepPartial, LogLevel, Number3Tuple, PartialNumber3Tuple } from '@/types'
 
 const logger = getLogger('editorStore')
 
@@ -60,7 +60,7 @@ type EditorState = {
   }) => void
 
   settings: Settings
-  setSettings: (newSettings: Partial<Settings>) => void
+  setSettings: (newSettings: DeepPartial<Settings>) => void
 
   resetProject: () => void
 }
@@ -87,7 +87,7 @@ export const useEditorStore = create(
       minLogLevel: 'info',
     }
     globalThis.__depl_alertUncaughtError =
-      initialSettings?.debug?.alertUncaughtErro
+      initialSettings?.debug?.alertUncaughtError
 
     return {
       mode: 'translate',

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -10,8 +10,8 @@ export type DeepPartial<T> = {
     ? T[P] extends Function
       ? T[P]
       : DeepPartial<T[P]>
-    : T[P];
-};
+    : T[P]
+}
 
 /**
  * ref에 커스텀 함수(callback)을 쓸 수 있으면서

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -1,6 +1,12 @@
 import { MutableRefObject, RefCallback } from 'react'
 import { Matrix4Tuple } from 'three'
 
+declare global {
+  interface Window {
+    __depl_alertUncaughtError?: boolean
+  }
+}
+
 /**
  * ref에 커스텀 함수(callback)을 쓸 수 있으면서
  * 동시에 `current` 값도 사용할 수 있는 Ref

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -2,10 +2,16 @@ import { MutableRefObject, RefCallback } from 'react'
 import { Matrix4Tuple } from 'three'
 
 declare global {
-  interface Window {
-    __depl_alertUncaughtError?: boolean
-  }
+  var __depl_alertUncaughtError: boolean | undefined
 }
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object
+    ? T[P] extends Function
+      ? T[P]
+      : DeepPartial<T[P]>
+    : T[P];
+};
 
 /**
  * ref에 커스텀 함수(callback)을 쓸 수 있으면서

--- a/packages/app/tailwind.config.js
+++ b/packages/app/tailwind.config.js
@@ -11,7 +11,11 @@ export default {
     '../../node_modules/@heroui/theme/dist/components/popover.js',
   ],
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        'xs': '400px'
+      }
+    },
   },
   darkMode: 'class',
   plugins: [tailwindAnimate, heroui()],

--- a/packages/asset-utils/.gitignore
+++ b/packages/asset-utils/.gitignore
@@ -134,3 +134,6 @@ dist
 workdir
 output/**/*
 !output/serve.json
+
+# vim swap files
+*.sw?

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,11 @@ overrides:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
 
   packages/app:
     dependencies:
@@ -150,6 +154,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.6.8
         version: 0.6.8(@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.3.3))(prettier@3.3.3)
+      pretty-quick:
+        specifier: ^4.2.2
+        version: 4.2.2(prettier@3.3.3)
       tailwindcss:
         specifier: ^3.4.13
         version: 3.4.13
@@ -755,6 +762,10 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@pkgr/core@0.2.7':
+    resolution: {integrity: sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
@@ -2264,11 +2275,20 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   immediate@3.0.6:
@@ -2609,6 +2629,10 @@ packages:
   motion-utils@12.0.0:
     resolution: {integrity: sha512-MNFiBKbbqnmvOjkPyOKgHUp3Q6oiokLkI1bEwm5QA28cxMZrv0CbbBGDNmhF6DIXsi1pCQBSs0dX8xjeER1tmA==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -2740,9 +2764,16 @@ packages:
   picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -2863,6 +2894,13 @@ packages:
     resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-quick@4.2.2:
+    resolution: {integrity: sha512-uAh96tBW1SsD34VhhDmWuEmqbpfYc/B3j++5MC/6b3Cb8Ow7NJsvKFhg0eoGu2xXX+o9RkahkTK6sUdd8E7g5w==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      prettier: ^3.0.0
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -3227,6 +3265,9 @@ packages:
   three@0.169.0:
     resolution: {integrity: sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -3259,6 +3300,9 @@ packages:
 
   tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.19.1:
     resolution: {integrity: sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==}
@@ -4008,6 +4052,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@pkgr/core@0.2.7': {}
 
   '@radix-ui/primitive@1.1.1': {}
 
@@ -5726,9 +5772,13 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  husky@9.1.7: {}
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   immediate@3.0.6: {}
 
@@ -6025,6 +6075,8 @@ snapshots:
 
   motion-utils@12.0.0: {}
 
+  mri@1.2.0: {}
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -6140,7 +6192,11 @@ snapshots:
 
   picocolors@1.1.0: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
+
+  picomatch@4.0.2: {}
 
   pify@2.3.0: {}
 
@@ -6196,6 +6252,17 @@ snapshots:
       '@trivago/prettier-plugin-sort-imports': 4.3.0(prettier@3.3.3)
 
   prettier@3.3.3: {}
+
+  pretty-quick@4.2.2(prettier@3.3.3):
+    dependencies:
+      '@pkgr/core': 0.2.7
+      ignore: 7.0.5
+      mri: 1.2.0
+      picocolors: 1.1.1
+      picomatch: 4.0.2
+      prettier: 3.3.3
+      tinyexec: 0.3.2
+      tslib: 2.8.1
 
   process-nextick-args@2.0.1: {}
 
@@ -6657,6 +6724,8 @@ snapshots:
 
   three@0.169.0: {}
 
+  tinyexec@0.3.2: {}
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
@@ -6684,6 +6753,8 @@ snapshots:
   ts-interface-checker@0.1.13: {}
 
   tslib@2.7.0: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.19.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-icons:
-        specifier: ^5.3.0
-        version: 5.3.0(react@18.3.1)
+        specifier: ^5.5.0
+        version: 5.5.0(react@18.3.1)
       swr:
         specifier: ^2.2.5
         version: 2.2.5(react@18.3.1)
@@ -2955,8 +2955,8 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-icons@5.3.0:
-    resolution: {integrity: sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==}
+  react-icons@5.5.0:
+    resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
     peerDependencies:
       react: '*'
 
@@ -6320,7 +6320,7 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-icons@5.3.0(react@18.3.1):
+  react-icons@5.5.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       immer:
         specifier: ^10.1.1
         version: 10.1.1
+      lodash.merge:
+        specifier: ^4.6.2
+        version: 4.6.2
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,10 @@ importers:
       zustand:
         specifier: 5.0.0-rc.2
         version: 5.0.0-rc.2(@types/react@18.3.11)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.2.2(react@18.3.1))
+    optionalDependencies:
+      '@swc/core-android-arm64':
+        specifier: ^1.3.11
+        version: 1.3.11
     devDependencies:
       '@eslint/js':
         specifier: ^9.11.1
@@ -1119,6 +1123,7 @@ packages:
 
   '@react-hookz/deep-equal@1.0.4':
     resolution: {integrity: sha512-N56fTrAPUDz/R423pag+n6TXWbvlBZDtTehaGFjK0InmN+V2OFWLE/WmORhmn6Ce7dlwH5+tQN1LJFw3ngTJVg==}
+    deprecated: Package is deprecated and will be deleted soon. Use @ver0/deep-equal instead.
 
   '@react-hookz/web@24.0.4':
     resolution: {integrity: sha512-DcIM6JiZklDyHF6CRD1FTXzuggAkQ+3Ncq2Wln7Kdih8GV6ZIeN9JfS6ZaQxpQUxan8/4n0J2V/R7nMeiSrb2Q==}
@@ -1345,6 +1350,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@swc/core-android-arm64@1.3.11':
+    resolution: {integrity: sha512-M7FamR3kFpVTyTw73FzKcOZmS7/TWHX75eqtwBTaU9fW4shf0KTLr/h9DnMxNKAnwUMeub/lqlINUe5EKFIKwQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [android]
+
   '@swc/core-darwin-arm64@1.7.26':
     resolution: {integrity: sha512-FF3CRYTg6a7ZVW4yT9mesxoVVZTrcSWtmZhxKCYJX9brH4CS/7PRPjAKNk6kzWgWuRoglP7hkjQcd6EpMcZEAw==}
     engines: {node: '>=10'}
@@ -1422,6 +1433,9 @@ packages:
 
   '@swc/types@0.1.12':
     resolution: {integrity: sha512-wBJA+SdtkbFhHjTMYH+dEH1y4VpfGdAc2Kw/LK09i9bXd/K6j6PkDcFCEzb6iVfZMkPRrl/q0e3toqTAJdkIVA==}
+
+  '@swc/wasm@1.2.130':
+    resolution: {integrity: sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==}
 
   '@tanstack/react-virtual@3.10.8':
     resolution: {integrity: sha512-VbzbVGSsZlQktyLrP5nxE+vE1ZR+U0NFAWPbJLoG2+DKPwd2D7dVICTVIIaYlJqX1ZCEnYDbaOpmMwbsyhBoIA==}
@@ -4584,6 +4598,11 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
+  '@swc/core-android-arm64@1.3.11':
+    dependencies:
+      '@swc/wasm': 1.2.130
+    optional: true
+
   '@swc/core-darwin-arm64@1.7.26':
     optional: true
 
@@ -4640,6 +4659,9 @@ snapshots:
   '@swc/types@0.1.12':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@swc/wasm@1.2.130':
+    optional: true
 
   '@tanstack/react-virtual@3.10.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7
+      r3f-perf:
+        specifier: ^7.2.3
+        version: 7.2.3(@react-three/fiber@8.17.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.169.0))(@types/react@18.3.11)(@types/three@0.169.0)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.169.0)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -864,6 +867,11 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-icons@1.3.2':
+    resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
+    peerDependencies:
+      react: ^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc
+
   '@radix-ui/react-id@1.1.0':
     resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
     peerDependencies:
@@ -1350,6 +1358,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@stitches/react@1.2.8':
+    resolution: {integrity: sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==}
+    peerDependencies:
+      react: '>= 16.3.0'
+
   '@swc/core-android-arm64@1.3.11':
     resolution: {integrity: sha512-M7FamR3kFpVTyTw73FzKcOZmS7/TWHX75eqtwBTaU9fW4shf0KTLr/h9DnMxNKAnwUMeub/lqlINUe5EKFIKwQ==}
     engines: {node: '>=10'}
@@ -1570,6 +1583,14 @@ packages:
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
       react: '>= 16.8.0'
+
+  '@utsubo/events@0.1.7':
+    resolution: {integrity: sha512-WB/GEj/0h27Bz8rJ0+CBtNz5mLT79ne1OjB7PUM4n0qLBqEDwm6yBzZC3j6tasHjlBPJDYZiBVIA1glaMlgZ5g==}
+    peerDependencies:
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@vitejs/plugin-react-swc@3.7.1':
     resolution: {integrity: sha512-vgWOY0i1EROUK0Ctg1hwhtC3SdcDjZcdit4Ups4aPkDcB1jYhmo+RMYWY87cmXMhvtD5uf8lV89j2w16vkdSVg==}
@@ -2035,6 +2056,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -2846,6 +2870,22 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  r3f-perf@7.2.3:
+    resolution: {integrity: sha512-4+P/N/bnO9D8nzdm3suL/NjPZK/HHdjwpvajhi8j7eB41i2ECN6lX9RXiKSpHzpsDi2ui1tBj6q7/sz5opoqXw==}
+    peerDependencies:
+      '@react-three/fiber': '>=8.0'
+      dom: '*'
+      react: '>=18.0'
+      react-dom: '>=18.0'
+      three: '>=0.133'
+    peerDependenciesMeta:
+      '@react-three/fiber':
+        optional: true
+      dom:
+        optional: true
+      react-dom:
+        optional: true
 
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
@@ -4056,6 +4096,10 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-icons@1.3.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+
   '@radix-ui/react-id@1.1.0(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
@@ -4598,6 +4642,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
+  '@stitches/react@1.2.8(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+
   '@swc/core-android-arm64@1.3.11':
     dependencies:
       '@swc/wasm': 1.2.130
@@ -4829,6 +4877,12 @@ snapshots:
   '@use-gesture/react@10.3.1(react@18.3.1)':
     dependencies:
       '@use-gesture/core': 10.3.1
+      react: 18.3.1
+
+  '@utsubo/events@0.1.7(react@18.3.1)':
+    dependencies:
+      eventemitter3: 4.0.7
+    optionalDependencies:
       react: 18.3.1
 
   '@vitejs/plugin-react-swc@3.7.1(@swc/helpers@0.5.13)(vite@5.4.8(@types/node@22.7.5))':
@@ -5458,6 +5512,8 @@ snapshots:
   estraverse@5.3.0: {}
 
   esutils@2.0.3: {}
+
+  eventemitter3@4.0.7: {}
 
   execa@5.1.1:
     dependencies:
@@ -6141,6 +6197,23 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  r3f-perf@7.2.3(@react-three/fiber@8.17.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.169.0))(@types/react@18.3.11)(@types/three@0.169.0)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.169.0):
+    dependencies:
+      '@radix-ui/react-icons': 1.3.2(react@18.3.1)
+      '@react-three/drei': 9.114.3(@react-three/fiber@8.17.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.169.0))(@types/react@18.3.11)(@types/three@0.169.0)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.169.0)
+      '@stitches/react': 1.2.8(react@18.3.1)
+      '@utsubo/events': 0.1.7(react@18.3.1)
+      react: 18.3.1
+      three: 0.169.0
+      zustand: 4.5.5(@types/react@18.3.11)(immer@10.1.1)(react@18.3.1)
+    optionalDependencies:
+      '@react-three/fiber': 8.17.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.169.0)
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/three'
+      - immer
 
   range-parser@1.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
         version: 4.3.0(prettier@3.3.3)
+      '@types/lodash.merge':
+        specifier: ^4.6.9
+        version: 4.6.9
       '@types/node':
         specifier: ^22.7.5
         version: 22.7.5
@@ -1485,6 +1488,12 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/lodash.merge@4.6.9':
+    resolution: {integrity: sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==}
+
+  '@types/lodash@4.17.17':
+    resolution: {integrity: sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==}
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
@@ -4743,6 +4752,12 @@ snapshots:
   '@types/estree@1.0.6': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/lodash.merge@4.6.9':
+    dependencies:
+      '@types/lodash': 4.17.17
+
+  '@types/lodash@4.17.17': {}
 
   '@types/node@22.7.5':
     dependencies:


### PR DESCRIPTION
모바일 환경에서도 편집기를 사용할 수 있도록 디자인 변경 및 기능 추가
- 사이드바가 우측에서 나오는 방식을 사용
  - 우측 하단에 사이드바를 열 수 있는 버튼 추가
- 화면 왼쪽에 드래그 모드를 활성화할 수 있는 버튼 추가
  - 버튼을 누르고 있을 때 화면 드래그해서 선택 가능
  - 버튼을 짧게 누르면 '항상 드래그' 모드 토글 가능
- 각종 dialog 등을 모바일 환경에서는 화면에 꽉 차게 띄우도록 변경
- 우측 하단에 전체 화면 토글 버튼 추가