### PR TITLE
refactor(app): replace swr with tanstack query

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -40,7 +40,6 @@
     "react-i18next": "^15.7.3",
     "react-icons": "^5.5.0",
     "semver": "^7.7.2",
-    "swr": "^2.3.5",
     "tailwind-merge": "^2.5.3",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.179.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,6 +21,7 @@
     "@react-hookz/web": "^25.1.1",
     "@react-three/drei": "^9.114.3",
     "@react-three/fiber": "^8.18.0",
+    "@tanstack/react-query": "^5.90.2",
     "@types/three": "^0.179.0",
     "@uiw/react-color-sketch": "^2.7.1",
     "async-mutex": "^0.5.0",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,3 +1,4 @@
+import { QueryClientProvider } from '@tanstack/react-query'
 import { useEffect } from 'react'
 
 import Scene from './Scene'
@@ -11,6 +12,7 @@ import ItemDisplaySelectDialog from './components/dialog/ItemDisplaySelectDialog
 import PromptDialog from './components/dialog/PromptDialog.tsx'
 import SettingsDialog from './components/dialog/SettingsDialog'
 import WelcomeDialog from './components/dialog/WelcomeDialog'
+import { queryClient } from './query.ts'
 import AutosaveService from './services/autosave'
 import { useDialogStore } from './stores/dialogStore'
 import { useEditorStore } from './stores/editorStore'
@@ -40,25 +42,27 @@ function App() {
   }, [])
 
   return (
-    <div className="relative h-full w-full overflow-hidden xs:flex xs:flex-row">
-      <div className="relative h-full w-full flex-1">
-        <Scene />
+    <QueryClientProvider client={queryClient}>
+      <div className="relative h-full w-full overflow-hidden xs:flex xs:flex-row">
+        <div className="relative h-full w-full flex-1">
+          <Scene />
 
-        {/* floating buttons */}
-        <LeftButtonPanel />
-        <TopButtonPanel />
-        <MobileBottomButtonPanel />
+          {/* floating buttons */}
+          <LeftButtonPanel />
+          <TopButtonPanel />
+          <MobileBottomButtonPanel />
+        </div>
+
+        <Sidebar />
+
+        <WelcomeDialog />
+        <PromptDialog />
+        <SettingsDialog />
+        <BlockDisplaySelectDialog />
+        <ItemDisplaySelectDialog />
+        <ExportToMinecraftDialog />
       </div>
-
-      <Sidebar />
-
-      <WelcomeDialog />
-      <PromptDialog />
-      <SettingsDialog />
-      <BlockDisplaySelectDialog />
-      <ItemDisplaySelectDialog />
-      <ExportToMinecraftDialog />
-    </div>
+    </QueryClientProvider>
   )
 }
 

--- a/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
@@ -3,7 +3,7 @@ import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useShallow } from 'zustand/shallow'
 
-import { getBlockList } from '@/fetcher'
+import { getBlockListQueryFn } from '@/queries/getBlockList'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
 import { useProjectStore } from '@/stores/projectStore'
@@ -33,7 +33,7 @@ const BlockDisplaySelectDialog: FC = () => {
 
   const { data: blocksListResponse } = useQuery({
     queryKey: ['blocks.json', targetGameVersion],
-    queryFn: firstOpened ? () => getBlockList(targetGameVersion) : skipToken,
+    queryFn: firstOpened ? getBlockListQueryFn : skipToken,
     staleTime: Infinity,
   })
   const blocks = (blocksListResponse?.blocks ?? []).map((d) => d.split('[')[0]) // 블록 이름 뒤에 붙는 `[up=true]` 등 blockstate 기본값 텍스트 제거

--- a/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
@@ -33,12 +33,10 @@ const BlockDisplaySelectDialog: FC = () => {
 
   const { data: blocksListResponse } = useQuery({
     queryKey: ['blocks.json', targetGameVersion],
-    queryFn: firstOpened ? getBlockList : skipToken,
+    queryFn: firstOpened ? () => getBlockList(targetGameVersion) : skipToken,
     staleTime: Infinity,
   })
-  const blocks = (blocksListResponse?.data.blocks ?? []).map(
-    (d) => d.split('[')[0],
-  ) // 블록 이름 뒤에 붙는 `[up=true]` 등 blockstate 기본값 텍스트 제거
+  const blocks = (blocksListResponse?.blocks ?? []).map((d) => d.split('[')[0]) // 블록 이름 뒤에 붙는 `[up=true]` 등 blockstate 기본값 텍스트 제거
 
   useEffect(() => {
     if (isOpen) {

--- a/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/BlockDisplaySelectDialog.tsx
@@ -1,13 +1,12 @@
+import { skipToken, useQuery } from '@tanstack/react-query'
 import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import useSWRImmutable from 'swr/immutable'
 import { useShallow } from 'zustand/shallow'
 
-import fetcher from '@/fetcher'
+import { getBlockList } from '@/fetcher'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
 import { useProjectStore } from '@/stores/projectStore'
-import { CDNBlocksListResponse } from '@/types'
 
 import Dialog from './Dialog'
 
@@ -32,10 +31,11 @@ const BlockDisplaySelectDialog: FC = () => {
 
   const closeDialog = () => setOpenedDialog(null)
 
-  const { data: blocksListResponse } = useSWRImmutable(
-    firstOpened ? ['/assets/minecraft/blocks.json', targetGameVersion] : null,
-    ([url]) => fetcher<CDNBlocksListResponse>(url as string),
-  )
+  const { data: blocksListResponse } = useQuery({
+    queryKey: ['blocks.json', targetGameVersion],
+    queryFn: firstOpened ? getBlockList : skipToken,
+    staleTime: Infinity,
+  })
   const blocks = (blocksListResponse?.data.blocks ?? []).map(
     (d) => d.split('[')[0],
   ) // 블록 이름 뒤에 붙는 `[up=true]` 등 blockstate 기본값 텍스트 제거

--- a/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
@@ -3,7 +3,7 @@ import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useShallow } from 'zustand/shallow'
 
-import { getItemList } from '@/fetcher'
+import { getItemListQueryFn } from '@/queries/getItemList'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
 import { useProjectStore } from '@/stores/projectStore'
@@ -33,7 +33,7 @@ const ItemDisplaySelectDialog: FC = () => {
 
   const { data: itemListResponse } = useQuery({
     queryKey: ['items.json', targetGameVersion],
-    queryFn: firstOpened ? () => getItemList(targetGameVersion) : skipToken,
+    queryFn: firstOpened ? getItemListQueryFn : skipToken,
     staleTime: Infinity,
   })
 

--- a/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
@@ -33,11 +33,11 @@ const ItemDisplaySelectDialog: FC = () => {
 
   const { data: itemListResponse } = useQuery({
     queryKey: ['items.json', targetGameVersion],
-    queryFn: firstOpened ? getItemList : skipToken,
+    queryFn: firstOpened ? () => getItemList(targetGameVersion) : skipToken,
     staleTime: Infinity,
   })
 
-  const items = itemListResponse?.data.items ?? []
+  const items = itemListResponse?.items ?? []
 
   useEffect(() => {
     if (isOpen) {

--- a/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
+++ b/packages/app/src/components/dialog/ItemDisplaySelectDialog.tsx
@@ -1,13 +1,12 @@
+import { skipToken, useQuery } from '@tanstack/react-query'
 import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import useSWRImmutable from 'swr/immutable'
 import { useShallow } from 'zustand/shallow'
 
-import fetcher from '@/fetcher'
+import { getItemList } from '@/fetcher'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
 import { useProjectStore } from '@/stores/projectStore'
-import { CDNItemsListResponse } from '@/types'
 
 import Dialog from './Dialog'
 
@@ -32,10 +31,11 @@ const ItemDisplaySelectDialog: FC = () => {
 
   const closeDialog = () => setOpenedDialog(null)
 
-  const { data: itemListResponse } = useSWRImmutable(
-    firstOpened ? ['/assets/minecraft/items.json', targetGameVersion] : null,
-    ([url]) => fetcher<CDNItemsListResponse>(url as string),
-  )
+  const { data: itemListResponse } = useQuery({
+    queryKey: ['items.json', targetGameVersion],
+    queryFn: firstOpened ? getItemList : skipToken,
+    staleTime: Infinity,
+  })
 
   const items = itemListResponse?.data.items ?? []
 

--- a/packages/app/src/components/sidebar/PropertiesPanel.tsx
+++ b/packages/app/src/components/sidebar/PropertiesPanel.tsx
@@ -553,6 +553,10 @@ const ProjectProperties: FC = () => {
                   useProjectStore
                     .getState()
                     .setTargetGameVersion(gameVersionData.id)
+                  useDisplayEntityStore
+                    .getState()
+                    .purgeInvalidEntities()
+                    .catch(console.error)
                   useHistoryStore.getState().clearHistory()
                 }
               },

--- a/packages/app/src/fetcher.ts
+++ b/packages/app/src/fetcher.ts
@@ -1,6 +1,7 @@
 import { CDNBaseUrl } from './constants'
 import { AssetFileInfosCache } from './stores/cacheStore'
 import { useProjectStore } from './stores/projectStore'
+import { CDNBlocksListResponse, CDNItemsListResponse } from './types'
 
 export default async function fetcher<T>(
   url: string,
@@ -33,4 +34,17 @@ export default async function fetcher<T>(
     fromVersion,
     data: fetchedData,
   }
+}
+
+export async function getBlockList() {
+  return await fetcher<CDNBlocksListResponse>(
+    '/assets/minecraft/blocks.json',
+    false,
+  )
+}
+export async function getItemList() {
+  return await fetcher<CDNItemsListResponse>(
+    '/assets/minecraft/items.json',
+    false,
+  )
 }

--- a/packages/app/src/fetcher.ts
+++ b/packages/app/src/fetcher.ts
@@ -1,11 +1,6 @@
 import { CDNBaseUrl } from './constants'
 import { AssetFileInfosCache } from './stores/cacheStore'
 import { useProjectStore } from './stores/projectStore'
-import {
-  CDNBlocksListResponse,
-  CDNItemsListResponse,
-  VersionMetadata,
-} from './types'
 
 export default async function fetcher<T>(
   url: string,
@@ -38,21 +33,4 @@ export default async function fetcher<T>(
     fromVersion,
     data: fetchedData,
   }
-}
-
-export async function getBlockList(gameVersion: string) {
-  return (await fetch(
-    `${CDNBaseUrl}/${gameVersion}/assets/minecraft/blocks.json`,
-  ).then((res) => res.json())) as CDNBlocksListResponse
-}
-export async function getItemList(gameVersion: string) {
-  return (await fetch(
-    `${CDNBaseUrl}/${gameVersion}/assets/minecraft/items.json`,
-  ).then((res) => res.json())) as CDNItemsListResponse
-}
-
-export async function getVersionMetadata(gameVersion: string) {
-  return (await fetch(`${CDNBaseUrl}/${gameVersion}/metadata.json`).then(
-    (res) => res.json(),
-  )) as VersionMetadata
 }

--- a/packages/app/src/fetcher.ts
+++ b/packages/app/src/fetcher.ts
@@ -36,15 +36,13 @@ export default async function fetcher<T>(
   }
 }
 
-export async function getBlockList() {
-  return await fetcher<CDNBlocksListResponse>(
-    '/assets/minecraft/blocks.json',
-    false,
-  )
+export async function getBlockList(gameVersion: string) {
+  return (await fetch(
+    `${CDNBaseUrl}/${gameVersion}/assets/minecraft/blocks.json`,
+  ).then((res) => res.json())) as CDNBlocksListResponse
 }
-export async function getItemList() {
-  return await fetcher<CDNItemsListResponse>(
-    '/assets/minecraft/items.json',
-    false,
-  )
+export async function getItemList(gameVersion: string) {
+  return (await fetch(
+    `${CDNBaseUrl}/${gameVersion}/assets/minecraft/items.json`,
+  ).then((res) => res.json())) as CDNItemsListResponse
 }

--- a/packages/app/src/fetcher.ts
+++ b/packages/app/src/fetcher.ts
@@ -1,7 +1,11 @@
 import { CDNBaseUrl } from './constants'
 import { AssetFileInfosCache } from './stores/cacheStore'
 import { useProjectStore } from './stores/projectStore'
-import { CDNBlocksListResponse, CDNItemsListResponse } from './types'
+import {
+  CDNBlocksListResponse,
+  CDNItemsListResponse,
+  VersionMetadata,
+} from './types'
 
 export default async function fetcher<T>(
   url: string,
@@ -45,4 +49,10 @@ export async function getItemList(gameVersion: string) {
   return (await fetch(
     `${CDNBaseUrl}/${gameVersion}/assets/minecraft/items.json`,
   ).then((res) => res.json())) as CDNItemsListResponse
+}
+
+export async function getVersionMetadata(gameVersion: string) {
+  return (await fetch(`${CDNBaseUrl}/${gameVersion}/metadata.json`).then(
+    (res) => res.json(),
+  )) as VersionMetadata
 }

--- a/packages/app/src/queries/getBlockList.ts
+++ b/packages/app/src/queries/getBlockList.ts
@@ -1,0 +1,20 @@
+import { QueryFunctionContext } from '@tanstack/react-query'
+
+import { CDNBaseUrl } from '@/constants'
+import { queryClient } from '@/query'
+import { CDNBlocksListResponse } from '@/types'
+
+export async function getBlockListQueryFn({ queryKey }: QueryFunctionContext) {
+  const [, gameVersion] = queryKey
+  return (await fetch(
+    `${CDNBaseUrl}/${gameVersion}/assets/minecraft/blocks.json`,
+  ).then((res) => res.json())) as CDNBlocksListResponse
+}
+
+export async function getBlockList(gameVersion: string) {
+  return await queryClient.fetchQuery({
+    queryKey: ['blocks.json', gameVersion],
+    queryFn: getBlockListQueryFn,
+    staleTime: Infinity,
+  })
+}

--- a/packages/app/src/queries/getItemList.ts
+++ b/packages/app/src/queries/getItemList.ts
@@ -1,0 +1,20 @@
+import { QueryFunctionContext } from '@tanstack/react-query'
+
+import { CDNBaseUrl } from '@/constants'
+import { queryClient } from '@/query'
+import { CDNItemsListResponse } from '@/types'
+
+export async function getItemListQueryFn({ queryKey }: QueryFunctionContext) {
+  const [, gameVersion] = queryKey
+  return (await fetch(
+    `${CDNBaseUrl}/${gameVersion}/assets/minecraft/items.json`,
+  ).then((res) => res.json())) as CDNItemsListResponse
+}
+
+export async function getItemList(gameVersion: string) {
+  return await queryClient.fetchQuery({
+    queryKey: ['items.json', gameVersion],
+    queryFn: getItemListQueryFn,
+    staleTime: Infinity,
+  })
+}

--- a/packages/app/src/queries/getVersionMetadata.ts
+++ b/packages/app/src/queries/getVersionMetadata.ts
@@ -1,0 +1,22 @@
+import { QueryFunctionContext } from '@tanstack/react-query'
+
+import { CDNBaseUrl } from '@/constants'
+import { queryClient } from '@/query'
+import { VersionMetadata } from '@/types'
+
+export async function getVersionMetadataQueryFn({
+  queryKey,
+}: QueryFunctionContext) {
+  const [, gameVersion] = queryKey
+  return (await fetch(`${CDNBaseUrl}/${gameVersion}/metadata.json`).then(
+    (res) => res.json(),
+  )) as VersionMetadata
+}
+
+export async function getVersionMetadata(gameVersion: string) {
+  return await queryClient.fetchQuery({
+    queryKey: ['getVersionMetadata', gameVersion],
+    queryFn: getVersionMetadataQueryFn,
+    staleTime: Infinity,
+  })
+}

--- a/packages/app/src/query.ts
+++ b/packages/app/src/query.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient()

--- a/packages/app/src/services/resources/font/unihex.ts
+++ b/packages/app/src/services/resources/font/unihex.ts
@@ -2,7 +2,8 @@ import { Mutex } from 'async-mutex'
 import { CanvasTexture } from 'three'
 
 import { CDNBaseUrl } from '@/constants'
-import { VersionMetadataCache } from '@/stores/cacheStore'
+import { getVersionMetadata } from '@/fetcher'
+import { queryClient } from '@/query'
 import { useProjectStore } from '@/stores/projectStore'
 import { CDNFontProviderResponse, type UnifontSizeOverrideEntry } from '@/types'
 
@@ -85,9 +86,12 @@ async function getCharPixels(char: string) {
   const charCode = char.charCodeAt(0)
 
   // TODO: Extract version metadata loading
-  const versionMetadata = await VersionMetadataCache.instance.fetch(
-    useProjectStore.getState().targetGameVersion,
-  )
+  const { targetGameVersion } = useProjectStore.getState()
+  const versionMetadata = await queryClient.fetchQuery({
+    queryKey: ['versionMetadata', targetGameVersion],
+    queryFn: () => getVersionMetadata(targetGameVersion),
+    staleTime: Infinity,
+  })
   const { assetIndex, unifontHexFilePath } = versionMetadata.sharedAssets
 
   const { hexData: unifontHexData, sizeOverrides } = await loadUnifontHexFile(

--- a/packages/app/src/services/resources/font/unihex.ts
+++ b/packages/app/src/services/resources/font/unihex.ts
@@ -2,8 +2,7 @@ import { Mutex } from 'async-mutex'
 import { CanvasTexture } from 'three'
 
 import { CDNBaseUrl } from '@/constants'
-import { getVersionMetadata } from '@/fetcher'
-import { queryClient } from '@/query'
+import { getVersionMetadata } from '@/queries/getVersionMetadata'
 import { useProjectStore } from '@/stores/projectStore'
 import { CDNFontProviderResponse, type UnifontSizeOverrideEntry } from '@/types'
 
@@ -87,11 +86,7 @@ async function getCharPixels(char: string) {
 
   // TODO: Extract version metadata loading
   const { targetGameVersion } = useProjectStore.getState()
-  const versionMetadata = await queryClient.fetchQuery({
-    queryKey: ['versionMetadata', targetGameVersion],
-    queryFn: () => getVersionMetadata(targetGameVersion),
-    staleTime: Infinity,
-  })
+  const versionMetadata = await getVersionMetadata(targetGameVersion)
   const { assetIndex, unifontHexFilePath } = versionMetadata.sharedAssets
 
   const { hexData: unifontHexData, sizeOverrides } = await loadUnifontHexFile(

--- a/packages/app/src/services/resources/textMesh.ts
+++ b/packages/app/src/services/resources/textMesh.ts
@@ -8,8 +8,7 @@ import {
   Texture,
 } from 'three'
 
-import { getVersionMetadata } from '@/fetcher'
-import { queryClient } from '@/query'
+import { getVersionMetadata } from '@/queries/getVersionMetadata'
 import { useClassObjectCacheStore } from '@/stores/cacheStore'
 import { useProjectStore } from '@/stores/projectStore'
 
@@ -195,11 +194,7 @@ async function createCharMesh(char: string, preferFont: Font, color: number) {
   if (preferFont === 'uniform') {
     // unifont glyphs need to be treated separately by assetIndex id
     const { targetGameVersion } = useProjectStore.getState()
-    const versionMetadata = await queryClient.fetchQuery({
-      queryKey: ['versionMetadata', targetGameVersion],
-      queryFn: () => getVersionMetadata(targetGameVersion),
-      staleTime: Infinity,
-    })
+    const versionMetadata = await getVersionMetadata(targetGameVersion)
     fontKey += `;${versionMetadata.sharedAssets.assetIndex}`
   }
   const key = `${fontKey};${char.charCodeAt(0).toString(16)}`

--- a/packages/app/src/stores/cacheStore.ts
+++ b/packages/app/src/stores/cacheStore.ts
@@ -11,7 +11,6 @@ import {
   BlockstatesData,
   FontProvider,
   ModelData,
-  VersionMetadata,
 } from '@/types'
 
 import { useProjectStore } from './projectStore'
@@ -157,50 +156,6 @@ export const useClassObjectCacheStore = create<ClassObjectCacheStoreState>(
       }),
   }),
 )
-
-export class VersionMetadataCache {
-  private static _instance: VersionMetadataCache
-
-  private _cache = new Map<string, VersionMetadata>()
-  private _fetchMutexMap = new Map<string, Mutex>()
-
-  private constructor() {}
-  static get instance() {
-    if (this._instance == null) {
-      this._instance = new VersionMetadataCache()
-    }
-
-    return this._instance
-  }
-
-  get(version: string) {
-    return this._cache.get(version)
-  }
-
-  async fetch(version: string) {
-    if (!this._fetchMutexMap.has(version)) {
-      this._fetchMutexMap.set(version, new Mutex())
-    }
-    const mutex = this._fetchMutexMap.get(version)!
-
-    return await mutex.runExclusive(async () => {
-      const existingData = this.get(version)
-      if (existingData != null) {
-        return existingData
-      }
-
-      const data = (await fetch(`${CDNBaseUrl}/${version}/metadata.json`).then(
-        (r) => r.json(),
-      )) as VersionMetadata
-      this._cache.set(version, data)
-      return data
-    })
-  }
-
-  clear() {
-    this._cache.clear()
-  }
-}
 
 export class AssetFileInfosCache {
   private static _instance: AssetFileInfosCache

--- a/packages/app/src/stores/displayEntityStore.ts
+++ b/packages/app/src/stores/displayEntityStore.ts
@@ -5,8 +5,8 @@ import { Box3, Euler, Matrix4, Quaternion, Vector3 } from 'three'
 import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 
-import { getBlockList, getItemList } from '@/fetcher'
-import { queryClient } from '@/query'
+import { getBlockList } from '@/queries/getBlockList'
+import { getItemList } from '@/queries/getItemList'
 import { getLogger } from '@/services/loggerService'
 import { preloadResources } from '@/services/resources/preload'
 import {
@@ -992,18 +992,12 @@ export const useDisplayEntityStore = create(
       // i know fetching without caching is shit, will fix later
 
       const { targetGameVersion } = useProjectStore.getState()
-      const blocksListResponse = await queryClient.fetchQuery({
-        queryKey: ['blocks.json', targetGameVersion],
-        queryFn: () => getBlockList(targetGameVersion),
-      })
+      const blocksListResponse = await getBlockList(targetGameVersion)
       const blocks = (blocksListResponse.blocks ?? []).map(
         (d) => d.split('[')[0],
       ) // 블록 이름 뒤에 붙는 `[up=true]` 등 blockstate 기본값 텍스트 제거
 
-      const itemsListResponse = await queryClient.fetchQuery({
-        queryKey: ['items.json', targetGameVersion],
-        queryFn: () => getItemList(targetGameVersion),
-      })
+      const itemsListResponse = await getItemList(targetGameVersion)
       const items = itemsListResponse.items
 
       const { entities, deleteEntities } = get()

--- a/packages/app/src/stores/projectStore.ts
+++ b/packages/app/src/stores/projectStore.ts
@@ -3,8 +3,6 @@ import { immer } from 'zustand/middleware/immer'
 
 import { LatestGameVersion } from '@/constants'
 
-import { useDisplayEntityStore } from './displayEntityStore'
-
 interface ProjectStoreState {
   targetGameVersion: string
   setTargetGameVersion: (version: string) => void
@@ -17,11 +15,6 @@ export const useProjectStore = create(
       set((state) => {
         state.targetGameVersion = version
       })
-
-      useDisplayEntityStore
-        .getState()
-        .purgeInvalidEntities()
-        .catch(console.error)
     },
   })),
 )

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -12,7 +12,12 @@ const commitHash = execSync('git rev-parse --short HEAD').toString()
 
 const plugins: PluginOption[] = [react()]
 if (process.env.GENERATE_BUILD_STATS) {
-  plugins.push(visualizer())
+  plugins.push(
+    visualizer({
+      gzipSize: true,
+      brotliSize: true,
+    }),
+  )
 }
 
 // https://vitejs.dev/config/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ importers:
       semver:
         specifier: ^7.7.2
         version: 7.7.2
-      swr:
-        specifier: ^2.3.5
-        version: 2.3.5(react@18.3.1)
       tailwind-merge:
         specifier: ^2.5.3
         version: 2.5.3
@@ -2336,10 +2333,6 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-
   detect-gpu@5.0.70:
     resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
 
@@ -3900,11 +3893,6 @@ packages:
     resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
     peerDependencies:
       react: '>=17.0'
-
-  swr@2.3.5:
-    resolution: {integrity: sha512-4e7pjTVulZTIL+b/S0RYFsgDcTcXPLUOvBPqyh9YdD+PkHeEMoaPwDmF9Kv6I1nnPg1OFKhiiEYpsYaaE2W2jA==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
@@ -6409,8 +6397,6 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  dequal@2.0.3: {}
-
   detect-gpu@5.0.70:
     dependencies:
       webgl-constants: 1.1.1
@@ -8165,12 +8151,6 @@ snapshots:
   suspend-react@0.1.3(react@18.3.1):
     dependencies:
       react: 18.3.1
-
-  swr@2.3.5(react@18.3.1):
-    dependencies:
-      dequal: 2.0.3
-      react: 18.3.1
-      use-sync-external-store: 1.5.0(react@18.3.1)
 
   tabbable@6.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@react-three/fiber':
         specifier: ^8.18.0
         version: 8.18.0(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.179.1)
+      '@tanstack/react-query':
+        specifier: ^5.90.2
+        version: 5.90.2(react@18.3.1)
       '@types/three':
         specifier: ^0.179.0
         version: 0.179.0
@@ -1733,6 +1736,14 @@ packages:
 
   '@swc/wasm@1.2.130':
     resolution: {integrity: sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==}
+
+  '@tanstack/query-core@5.90.2':
+    resolution: {integrity: sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==}
+
+  '@tanstack/react-query@5.90.2':
+    resolution: {integrity: sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-virtual@3.13.12':
     resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
@@ -5696,6 +5707,13 @@ snapshots:
 
   '@swc/wasm@1.2.130':
     optional: true
+
+  '@tanstack/query-core@5.90.2': {}
+
+  '@tanstack/react-query@5.90.2(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.90.2
+      react: 18.3.1
 
   '@tanstack/react-virtual@3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
지금까지는 react 내부에서의 query 라이브러리로 SWR을 쓰고 있었습니다.
그러나 SWR은 React hook으로만 제공되어서, hook을 쓸 수 없는 컴포넌트 외부에서는 별도의 fetch와 캐싱 시스템을 활용해야 했습니다.

이러한 불편을 해소하고자 query 라이브러리를 React 밖에서도 사용할 수 있는 Tanstack Query로 교체합니다.
Tanstack Query는 `QueryClient`를 한 번만 만들어 React 내부와 외부에서 동일하게 사용할 수 있고, 캐시도 공유됩니다.
