### PR TITLE
release v1.5.1

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/app/src/services/resources/material.ts
+++ b/packages/app/src/services/resources/material.ts
@@ -108,13 +108,23 @@ export async function loadMaterial({
       const canvas = document.createElement('canvas')
       const ctx = canvas.getContext('2d')!
 
-      const { width, height } = img
-
-      // 텍스쳐 사진을 처음 로드했을 경우 맨 위 width x height 만큼 잘라서 적용
+      const { width } = img
       canvas.width = width
-      canvas.height = height
+      // 애니메이션이 있는 블록들은 세로로 각 애니메이션 프레임을 붙여놨으므로
+      // 맨 처음 프레임만 잘라서 로드
+      canvas.height = width
 
-      ctx.drawImage(img, 0, 0, width, height, 0, 0, width, height)
+      ctx.drawImage(
+        img,
+        0,
+        0,
+        canvas.width,
+        canvas.height,
+        0,
+        0,
+        canvas.width,
+        canvas.height,
+      )
 
       const croppedTextureDataUrl = canvas.toDataURL()
       cachedCroppedTextureDataUrl = croppedTextureDataUrl


### PR DESCRIPTION
- 애니메이션이 있는 블록 텍스쳐 로드 시 맨 첫번째 프레임만 로드하도록 수정
  - 이전에 model 파일에 정의된 `texture_size` 값을 기준으로 잘라냈으나, 1.5.0에서 제거하면서 문제가 발생
  - 따라서 이미지의 가로 사이즈 기준으로 세로 사이즈를 맞추는 방식으로 변경