### PR TITLE
release v1.7.2 (hotfix)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/app/src/components/TransformControls.tsx
+++ b/packages/app/src/components/TransformControls.tsx
@@ -224,6 +224,17 @@ const TransformControls: FC = () => {
         onMouseDown={() => {
           setUsingTransformControl(true)
           logger.debug('onMouseDown')
+
+          // TODO: iterate over selected entities, update position/rotation/scale
+          // from displayEntityStore state to selectedEntityInitialTransformation ref storage
+          // This fixes the bug where manually changing selected entities' transformation data using TransformationPanel on sidebar and moving with dragging
+          // causes selected entities to be teleported weirdly because selectedEntityInitialTransformation holds old values on displayEntityStore state change
+
+          for (const initialTransform of selectedEntityInitialTransformations.current) {
+            initialTransform.position.copy(initialTransform.object.position)
+            initialTransform.quaternion.copy(initialTransform.object.quaternion)
+            initialTransform.scale.copy(initialTransform.object.scale)
+          }
         }}
         onMouseUp={() => {
           setUsingTransformControl(false)

--- a/packages/app/src/components/TransformControls.tsx
+++ b/packages/app/src/components/TransformControls.tsx
@@ -71,12 +71,15 @@ const TransformControls: FC = () => {
     rotationSpace,
     setUsingTransformControl,
     setSelectionBaseTransformation,
+    needsSelectedEntitiesInitialTransformationsUpdate,
   } = useEditorStore(
     useShallow((state) => ({
       mode: state.mode,
       rotationSpace: state.rotationSpace,
       setUsingTransformControl: state.setUsingTransformControl,
       setSelectionBaseTransformation: state.setSelectionBaseTransformation,
+      needsSelectedEntitiesInitialTransformationsUpdate:
+        state.transformControl.needsSelectedEntitiesTransformationUpdate,
     })),
   )
 
@@ -116,28 +119,8 @@ const TransformControls: FC = () => {
     })
   }, [selectedEntityIds])
 
-  // reparent pivot when first selected entity is changed
-  useEffect(() => {
-    logger.debug('reparenting pivot')
-    const { rootGroupRefData } = useEntityRefStore.getState()
-
-    if (firstSelectedEntityRefData != null) {
-      const parent =
-        firstSelectedEntityRefData.objectRef.current.parent ??
-        rootGroupRefData.objectRef.current
-      parent.add(pivot)
-    } else {
-      const parent = rootGroupRefData.objectRef.current
-      parent.add(pivot)
-    }
-  }, [firstSelectedEntityRefData, pivot])
-
-  useEffect(() => {
-    updateBoundingBox()
-  }, [selectedEntityIds, updateBoundingBox])
-
-  useEffect(() => {
-    const { entities } = useDisplayEntityStore.getState()
+  const updateSelectedEntityInitialTransformations = useCallback(() => {
+    const { entities, selectedEntityIds } = useDisplayEntityStore.getState()
     const selectedEntities = [...entities.values()].filter((e) =>
       selectedEntityIds.includes(e.id),
     )
@@ -163,14 +146,51 @@ const TransformControls: FC = () => {
         scale: scaleVec,
       })
     }
+  }, [])
 
+  // reparent pivot when first selected entity is changed
+  useEffect(() => {
+    logger.debug('reparenting pivot')
+    const { rootGroupRefData } = useEntityRefStore.getState()
+
+    if (firstSelectedEntityRefData != null) {
+      const parent =
+        firstSelectedEntityRefData.objectRef.current.parent ??
+        rootGroupRefData.objectRef.current
+      parent.add(pivot)
+    } else {
+      const parent = rootGroupRefData.objectRef.current
+      parent.add(pivot)
+    }
+  }, [firstSelectedEntityRefData, pivot])
+
+  // update when selected entity changes
+  useEffect(() => {
+    updateSelectedEntityInitialTransformations()
+
+    // selection bounding box shows when multiple entities are selected
     if (selectedEntityIds.length > 1) {
       updateBoundingBox()
     }
   }, [
-    // entities,
     selectedEntityIds,
-    firstSelectedEntityId,
+    updateSelectedEntityInitialTransformations,
+    updateBoundingBox,
+  ])
+
+  // updates when selected entities' transformations changes outside of TransformControls
+  useEffect(() => {
+    if (needsSelectedEntitiesInitialTransformationsUpdate) {
+      updateSelectedEntityInitialTransformations()
+      updateBoundingBox()
+
+      useEditorStore
+        .getState()
+        .transformControl.setSelectedEntitiesTransformationUpdateFlag(false)
+    }
+  }, [
+    needsSelectedEntitiesInitialTransformationsUpdate,
+    updateSelectedEntityInitialTransformations,
     updateBoundingBox,
   ])
 

--- a/packages/app/src/stores/displayEntityStore.ts
+++ b/packages/app/src/stores/displayEntityStore.ts
@@ -393,6 +393,11 @@ export const useDisplayEntityStore = create(
           { beforeState: Number3Tuple; afterState: Number3Tuple }
         >()
 
+        const { selectedEntityIds } = state
+        let shouldUpdateTransformControlSelectedEntitiesData = false
+
+        let hasChanges = false
+
         data.forEach((item) => {
           const entity = state.entities.get(item.id)
           if (entity == null) return
@@ -411,6 +416,7 @@ export const useDisplayEntityStore = create(
             })
 
             entity.position = positionDraft
+            hasChanges = true
           }
           if (item.rotation != null) {
             const rotationDraft = entity.rotation.slice() as Number3Tuple
@@ -426,6 +432,7 @@ export const useDisplayEntityStore = create(
             })
 
             entity.rotation = rotationDraft
+            hasChanges = true
           }
           if (item.scale != null) {
             const scaleDraft = entity.size.slice() as Number3Tuple
@@ -441,8 +448,24 @@ export const useDisplayEntityStore = create(
             })
 
             entity.size = scaleDraft
+            hasChanges = true
+          }
+
+          if (
+            !shouldUpdateTransformControlSelectedEntitiesData &&
+            hasChanges &&
+            selectedEntityIds.includes(item.id)
+          ) {
+            // set update flag when this entity is selected and has entity transformation changes
+            shouldUpdateTransformControlSelectedEntitiesData = true
           }
         })
+
+        if (shouldUpdateTransformControlSelectedEntitiesData) {
+          useEditorStore
+            .getState()
+            .transformControl.setSelectedEntitiesTransformationUpdateFlag(true)
+        }
 
         if (!skipHistoryAdd) {
           const { entities } = get()

--- a/packages/app/src/stores/editorStore.ts
+++ b/packages/app/src/stores/editorStore.ts
@@ -47,6 +47,11 @@ type EditorState = {
     size?: PartialNumber3Tuple
   }) => void
 
+  transformControl: {
+    needsSelectedEntitiesTransformationUpdate: boolean
+    setSelectedEntitiesTransformationUpdateFlag: (value: boolean) => void
+  }
+
   projectDirty: boolean
   setProjectDirty: (isDirty: boolean) => void
 
@@ -145,6 +150,17 @@ export const useEditorStore = create(
             state.selectionBaseTransformation.size = scaleDraft
           }
         }),
+
+      transformControl: {
+        // This flag is used by TransformControls to refetch entities' initial transformation on changes outside of TransformControls
+        // acting as a global store-based signaling.
+        needsSelectedEntitiesTransformationUpdate: false,
+        setSelectedEntitiesTransformationUpdateFlag: (value) =>
+          set((state) => {
+            state.transformControl.needsSelectedEntitiesTransformationUpdate =
+              value
+          }),
+      },
 
       projectDirty: false,
       setProjectDirty: (isDirty) =>


### PR DESCRIPTION
- 여러 개의 엔티티를 선택한 상태로 사이드바에서 엔티티들의 위치/방향/크기를 조절한 이후 메인 편집화면의 컨트롤을 드래그하여 엔티티의 위치/방향/크기를 조절하려고 시도할 경우 해당 엔티티들이 이상한 위치로 순간이동되는 버그를 수정했습니다.
- 여러 개의 엔티티를 선택한 상태로 사이드바에서 엔티티들의 위치/방향/크기를 조절할 때 선택된 엔티티들을 감싸는 흰색 테두리 박스가 실시간으로 갱신되지 않던 버그를 수정했습니다.

위 두 버그들은 a164e4e0025333370e368c2e4dc2e738bd2db834 커밋부터 발생하기 시작한 것으로 확인됩니다.
해당 커밋은 에디터의 TransformControl 관련해서 고질적인 버그(#37)를 고친 커밋 중 하나로, v1.6.0에 포함되어 있어
해당 버전부터 이 버그들이 발생하였습니다.