### PR TITLE
release v1.9.1

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/app/src/stores/displayEntityStore.ts
+++ b/packages/app/src/stores/displayEntityStore.ts
@@ -446,7 +446,9 @@ export const useDisplayEntityStore = create(
             f(d, clonedEntity.id),
           )
           // set children entity id array to cloned one
-          clonedEntity.children = clonedChildren.map((entity) => entity.id)
+          clonedEntity.children = clonedChildren
+            .filter((entity) => entity.parent === clonedEntity.id)
+            .map((entity) => entity.id)
 
           // put cloned children entities to list
           for (const child of clonedChildren) {


### PR DESCRIPTION
## 버그 수정
- 다중 중첩된 그룹을 복제했을 때, 그룹 내 동일한 그룹이나 디스플레이 엔티티가 2번 이상 등장하는 현상을 수정했습니다.
  - 복제된 최상단 그룹에 그룹 계층 구조와 상관없이 복제된 **모든** 엔티티나 그룹이 들어가면서 구조가 꼬여 생긴 문제입니다.

| 원래 그룹 | 복제된 그룹 |
|--------|--------|
| <img width="691" height="491" alt="image" src="https://github.com/user-attachments/assets/2fb67976-83e7-440d-897a-e432db1125af" /> | <img width="674" height="473" alt="image" src="https://github.com/user-attachments/assets/e2c027e0-971b-4646-8aaf-0b77f635b39f" /> |