### PR TITLE
feat(app): add context menu

### DIFF
--- a/packages/app/public/locales/en/translation.json
+++ b/packages/app/public/locales/en/translation.json
@@ -320,5 +320,11 @@
   },
   "dropzone": {
     "text": "Drop project file to open"
+  },
+  "contextMenu": {
+    "duplicate": "Duplicate",
+    "group": "Group",
+    "selectAll": "Select All",
+    "delete": "Delete"
   }
 }

--- a/packages/app/public/locales/ko/translation.json
+++ b/packages/app/public/locales/ko/translation.json
@@ -328,5 +328,11 @@
   },
   "dropzone": {
     "text": "여기에 프로젝트 파일을 드롭하여 열기"
+  },
+  "contextMenu": {
+    "duplicate": "복제",
+    "group": "그룹",
+    "selectAll": "전체 선택",
+    "delete": "삭제"
   }
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -15,6 +15,12 @@ import Modal from './components/dialog/Modal.tsx'
 import PlayerHeadBakingDialog from './components/dialog/PlayerHeadBakingDialog'
 import SettingsDialog from './components/dialog/SettingsDialog'
 import WelcomeDialog from './components/dialog/WelcomeDialog'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from './components/ui/context-menu'
 import { TooltipProvider } from './components/ui/tooltip'
 import { queryClient } from './lib/query.ts'
 import AutosaveService from './lib/services/autosave.service.ts'
@@ -64,7 +70,18 @@ function App() {
           <div className="relative h-full flex-1 overflow-hidden">
             {/* overflow-hidden is required to prevent child canvas width height from affecting parent div
               and correctly measure parent container size for canvas resizing */}
-            <Scene />
+            <ContextMenu>
+              <ContextMenuTrigger className="h-full w-full">
+                <Scene />
+              </ContextMenuTrigger>
+              <ContextMenuContent className="origin-top-left">
+                <ContextMenuItem>test item</ContextMenuItem>
+                <ContextMenuItem>test item</ContextMenuItem>
+                <ContextMenuItem>test item</ContextMenuItem>
+                <ContextMenuItem>test item</ContextMenuItem>
+                <ContextMenuItem>test item</ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
 
             {/* floating buttons */}
             <LeftButtonPanel />

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query'
 import { type FC, useEffect } from 'react'
 
+import ContextMenuHandler from './components/ContextMenuHandler'
 import FileDropzone from './components/FileDropzone'
 import LeftButtonPanel from './components/LeftButtonPanel'
 import MobileBottomButtonPanel from './components/MobileBottomButtonPanel'
@@ -15,12 +16,6 @@ import Modal from './components/dialog/Modal.tsx'
 import PlayerHeadBakingDialog from './components/dialog/PlayerHeadBakingDialog'
 import SettingsDialog from './components/dialog/SettingsDialog'
 import WelcomeDialog from './components/dialog/WelcomeDialog'
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from './components/ui/context-menu'
 import { TooltipProvider } from './components/ui/tooltip'
 import { queryClient } from './lib/query.ts'
 import AutosaveService from './lib/services/autosave.service.ts'
@@ -70,18 +65,9 @@ function App() {
           <div className="relative h-full flex-1 overflow-hidden">
             {/* overflow-hidden is required to prevent child canvas width height from affecting parent div
               and correctly measure parent container size for canvas resizing */}
-            <ContextMenu>
-              <ContextMenuTrigger className="h-full w-full">
-                <Scene />
-              </ContextMenuTrigger>
-              <ContextMenuContent className="origin-top-left">
-                <ContextMenuItem>test item</ContextMenuItem>
-                <ContextMenuItem>test item</ContextMenuItem>
-                <ContextMenuItem>test item</ContextMenuItem>
-                <ContextMenuItem>test item</ContextMenuItem>
-                <ContextMenuItem>test item</ContextMenuItem>
-              </ContextMenuContent>
-            </ContextMenu>
+            <ContextMenuHandler triggerClassName="h-full w-full">
+              <Scene />
+            </ContextMenuHandler>
 
             {/* floating buttons */}
             <LeftButtonPanel />

--- a/packages/app/src/components/ContextMenuHandler.tsx
+++ b/packages/app/src/components/ContextMenuHandler.tsx
@@ -1,0 +1,90 @@
+import type { FC, ReactNode } from 'react'
+import { LuCopyPlus, LuGroup, LuScan, LuTrash } from 'react-icons/lu'
+
+import {
+  cloneSelectedEntities,
+  deleteEntities,
+  groupEntities,
+} from '@/lib/entities'
+import { useDisplayEntityStore } from '@/stores/displayEntityStore'
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from './ui/context-menu'
+
+// split actual context menu content to prevent rendering context menu trigger item
+// when context menu content needs to be rerendered by external data change
+const ContextMenuContentArea: FC = () => {
+  const selectedEntityIds = useDisplayEntityStore(
+    (state) => state.selectedEntityIds,
+  )
+  const someItemsSelected = selectedEntityIds.length > 0
+
+  return (
+    <ContextMenuContent className="min-w-48 origin-top-left">
+      <ContextMenuItem
+        disabled={!someItemsSelected}
+        onClick={() => {
+          cloneSelectedEntities()
+        }}
+      >
+        <LuCopyPlus /> Duplicate
+      </ContextMenuItem>
+      <ContextMenuItem
+        disabled={!someItemsSelected}
+        onClick={() => {
+          groupEntities(selectedEntityIds)
+        }}
+      >
+        <LuGroup /> Group
+      </ContextMenuItem>
+
+      <ContextMenuSeparator />
+
+      <ContextMenuItem
+        onClick={() => {
+          const { entities, setSelected } = useDisplayEntityStore.getState()
+          const rootEntityIds = [...entities.values()]
+            .filter((entity) => entity.parent == null)
+            .map((entity) => entity.id)
+          setSelected(rootEntityIds)
+        }}
+      >
+        <LuScan /> Select All
+      </ContextMenuItem>
+
+      <ContextMenuSeparator />
+      <ContextMenuItem
+        variant="destructive"
+        disabled={!someItemsSelected}
+        onClick={() => {
+          deleteEntities(selectedEntityIds)
+        }}
+      >
+        <LuTrash /> Delete
+      </ContextMenuItem>
+    </ContextMenuContent>
+  )
+}
+
+interface ContextMenuHandlerProps {
+  children: ReactNode
+  triggerClassName?: string
+}
+const ContextMenuHandler: FC<ContextMenuHandlerProps> = ({
+  children,
+  triggerClassName: className,
+}) => {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger className={className}>{children}</ContextMenuTrigger>
+      <ContextMenuContentArea />
+    </ContextMenu>
+  )
+}
+
+export default ContextMenuHandler

--- a/packages/app/src/components/ContextMenuHandler.tsx
+++ b/packages/app/src/components/ContextMenuHandler.tsx
@@ -1,4 +1,5 @@
 import { type FC, type ReactNode, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { LuCopyPlus, LuGroup, LuScan, LuTrash } from 'react-icons/lu'
 
 import {
@@ -19,6 +20,8 @@ import {
 // split actual context menu content to prevent rendering context menu trigger item
 // when context menu content needs to be rerendered by external data change
 const ContextMenuContentArea: FC = () => {
+  const { t } = useTranslation()
+
   const selectedEntityIds = useDisplayEntityStore(
     (state) => state.selectedEntityIds,
   )
@@ -32,7 +35,7 @@ const ContextMenuContentArea: FC = () => {
           cloneSelectedEntities()
         }}
       >
-        <LuCopyPlus /> Duplicate
+        <LuCopyPlus /> {t(($) => $.contextMenu.duplicate)}
       </ContextMenuItem>
       <ContextMenuItem
         disabled={!someItemsSelected}
@@ -40,7 +43,7 @@ const ContextMenuContentArea: FC = () => {
           groupEntities(selectedEntityIds)
         }}
       >
-        <LuGroup /> Group
+        <LuGroup /> {t(($) => $.contextMenu.group)}
       </ContextMenuItem>
 
       <ContextMenuSeparator />
@@ -54,7 +57,7 @@ const ContextMenuContentArea: FC = () => {
           setSelected(rootEntityIds)
         }}
       >
-        <LuScan /> Select All
+        <LuScan /> {t(($) => $.contextMenu.selectAll)}
       </ContextMenuItem>
 
       <ContextMenuSeparator />
@@ -65,7 +68,7 @@ const ContextMenuContentArea: FC = () => {
           deleteEntities(selectedEntityIds)
         }}
       >
-        <LuTrash /> Delete
+        <LuTrash /> {t(($) => $.contextMenu.delete)}
       </ContextMenuItem>
     </ContextMenuContent>
   )

--- a/packages/app/src/components/ContextMenuHandler.tsx
+++ b/packages/app/src/components/ContextMenuHandler.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react'
+import { type FC, type ReactNode, useEffect, useRef, useState } from 'react'
 import { LuCopyPlus, LuGroup, LuScan, LuTrash } from 'react-icons/lu'
 
 import {
@@ -79,9 +79,33 @@ const ContextMenuHandler: FC<ContextMenuHandlerProps> = ({
   children,
   triggerClassName: className,
 }) => {
+  const [disableMenu, setDisableMenu] = useState(false)
+
+  const triggerRef = useRef<HTMLDivElement>(null)
+
+  // disable context menu from triggering when dragging with right mouse button pressed
+  // which acts as canvas panning
+  useEffect(() => {
+    const triggerElement = triggerRef.current
+    const handle = (evt: MouseEvent) => {
+      if (evt.buttons === 2) {
+        setDisableMenu(true)
+      } else {
+        setDisableMenu(false)
+      }
+    }
+
+    triggerElement?.addEventListener('mousemove', handle)
+    return () => {
+      triggerElement?.removeEventListener('mousemove', handle)
+    }
+  }, [])
+
   return (
-    <ContextMenu>
-      <ContextMenuTrigger className={className}>{children}</ContextMenuTrigger>
+    <ContextMenu disabled={disableMenu}>
+      <ContextMenuTrigger className={className} ref={triggerRef}>
+        {children}
+      </ContextMenuTrigger>
       <ContextMenuContentArea />
     </ContextMenu>
   )

--- a/packages/app/src/components/ui/context-menu.tsx
+++ b/packages/app/src/components/ui/context-menu.tsx
@@ -14,18 +14,21 @@ function ContextMenuPortal({ ...props }: ContextMenuPrimitive.Portal.Props) {
   )
 }
 
-function ContextMenuTrigger({
-  className,
-  ...props
-}: ContextMenuPrimitive.Trigger.Props) {
+// TODO: remove forwardRef after react v19 update
+const ContextMenuTrigger = React.forwardRef<
+  HTMLDivElement,
+  ContextMenuPrimitive.Trigger.Props
+>(({ className, ...props }, ref) => {
   return (
     <ContextMenuPrimitive.Trigger
       data-slot="context-menu-trigger"
       className={cn('select-none', className)}
       {...props}
+      ref={ref}
     />
   )
-}
+})
+ContextMenuTrigger.displayName = 'ContextMenuTrigger'
 
 function ContextMenuContent({
   className,

--- a/packages/app/src/components/ui/context-menu.tsx
+++ b/packages/app/src/components/ui/context-menu.tsx
@@ -1,0 +1,271 @@
+import { ContextMenu as ContextMenuPrimitive } from '@base-ui/react/context-menu'
+import * as React from 'react'
+import { LuCheck, LuChevronRight } from 'react-icons/lu'
+
+import { cn } from '@/lib/utils'
+
+function ContextMenu({ ...props }: ContextMenuPrimitive.Root.Props) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+}
+
+function ContextMenuPortal({ ...props }: ContextMenuPrimitive.Portal.Props) {
+  return (
+    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+  )
+}
+
+function ContextMenuTrigger({
+  className,
+  ...props
+}: ContextMenuPrimitive.Trigger.Props) {
+  return (
+    <ContextMenuPrimitive.Trigger
+      data-slot="context-menu-trigger"
+      className={cn('select-none', className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuContent({
+  className,
+  align = 'start',
+  alignOffset = 4,
+  side = 'right',
+  sideOffset = 0,
+  ...props
+}: ContextMenuPrimitive.Popup.Props &
+  Pick<
+    ContextMenuPrimitive.Positioner.Props,
+    'align' | 'alignOffset' | 'side' | 'sideOffset'
+  >) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <ContextMenuPrimitive.Popup
+          data-slot="context-menu-content"
+          className={cn(
+            // 'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 max-h-(--available-height) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg p-1 shadow-md ring-1 duration-500 outline-none',
+            'data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 z-10 min-w-32 overflow-x-hidden overflow-y-auto rounded-lg p-1 shadow-md ring-1 outline-none',
+            className,
+          )}
+          {...props}
+        />
+      </ContextMenuPrimitive.Positioner>
+    </ContextMenuPrimitive.Portal>
+  )
+}
+
+function ContextMenuGroup({ ...props }: ContextMenuPrimitive.Group.Props) {
+  return (
+    <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
+  )
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: ContextMenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.GroupLabel
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        'text-muted-foreground px-1.5 py-1 text-xs font-medium data-inset:pl-7',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: ContextMenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: 'default' | 'destructive'
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/context-menu-item focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-7 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSub({ ...props }: ContextMenuPrimitive.SubmenuRoot.Props) {
+  return (
+    <ContextMenuPrimitive.SubmenuRoot data-slot="context-menu-sub" {...props} />
+  )
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: ContextMenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.SubmenuTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none data-inset:pl-7 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <LuChevronRight className="cn-rtl-flip ml-auto" />
+    </ContextMenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function ContextMenuSubContent({
+  ...props
+}: React.ComponentProps<typeof ContextMenuContent>) {
+  return (
+    <ContextMenuContent
+      data-slot="context-menu-sub-content"
+      className="shadow-lg"
+      side="right"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: ContextMenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-7 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2">
+        <ContextMenuPrimitive.CheckboxItemIndicator>
+          <LuCheck />
+        </ContextMenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  )
+}
+
+function ContextMenuRadioGroup({
+  ...props
+}: ContextMenuPrimitive.RadioGroup.Props) {
+  return (
+    <ContextMenuPrimitive.RadioGroup
+      data-slot="context-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: ContextMenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-7 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2">
+        <ContextMenuPrimitive.RadioItemIndicator>
+          <LuCheck />
+        </ContextMenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  )
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: ContextMenuPrimitive.Separator.Props) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        'text-muted-foreground group-focus/context-menu-item:text-accent-foreground ml-auto text-xs tracking-widest',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+}


### PR DESCRIPTION
에디터 화면을 우클릭했을 때 우클릭 메뉴가 뜨도록 추가합니다.

<img width="500" height="350" alt="image" src="https://github.com/user-attachments/assets/a944afac-ce81-40d4-9f8d-fdef20a9889b" />

- 현재 선택할 수 있는 메뉴 항목은 `복제`, `그룹`, `전체 선택`, `삭제`가 있으며, 앱에 기능이 추가되면서 더 늘어날 수 있습니다.
- 마우스를 사용하는 환경에서 우클릭하면서 드래그할 때 에디터 카메라 시점 이동 기능과 겹치는 것을 막기 위해, 우클릭하면서 드래그할 경우 메뉴가 뜨지 않도록 구현했습니다.