### PR TITLE
feat(app): copy-paste

### DIFF
--- a/packages/app/public/locales/en/translation.json
+++ b/packages/app/public/locales/en/translation.json
@@ -322,6 +322,7 @@
     "text": "Drop project file to open"
   },
   "contextMenu": {
+    "copy": "Copy",
     "duplicate": "Duplicate",
     "group": "Group",
     "selectAll": "Select All",

--- a/packages/app/public/locales/en/translation.json
+++ b/packages/app/public/locales/en/translation.json
@@ -149,6 +149,8 @@
             "general": {
               "title": "General",
               "items": {
+                "copy": "Copy",
+                "paste": "Paste",
                 "openFromFile": "Open from file",
                 "saveToFile": "Save to file",
                 "openSettings": "Open Settings",

--- a/packages/app/public/locales/en/translation.json
+++ b/packages/app/public/locales/en/translation.json
@@ -323,6 +323,7 @@
   },
   "contextMenu": {
     "copy": "Copy",
+    "paste": "Paste",
     "duplicate": "Duplicate",
     "group": "Group",
     "selectAll": "Select All",

--- a/packages/app/public/locales/ko/translation.json
+++ b/packages/app/public/locales/ko/translation.json
@@ -149,6 +149,8 @@
             "general": {
               "title": "일반",
               "items": {
+                "copy": "복사",
+                "paste": "붙여넣기",
                 "openFromFile": "파일에서 열기",
                 "saveToFile": "파일로 저장",
                 "openSettings": "설정 열기",

--- a/packages/app/public/locales/ko/translation.json
+++ b/packages/app/public/locales/ko/translation.json
@@ -328,6 +328,7 @@
   },
   "contextMenu": {
     "copy": "복사",
+    "paste": "붙여넣기",
     "duplicate": "복제",
     "group": "그룹",
     "selectAll": "전체 선택",

--- a/packages/app/public/locales/ko/translation.json
+++ b/packages/app/public/locales/ko/translation.json
@@ -327,6 +327,7 @@
     "text": "여기에 프로젝트 파일을 드롭하여 열기"
   },
   "contextMenu": {
+    "copy": "복사",
     "duplicate": "복제",
     "group": "그룹",
     "selectAll": "전체 선택",

--- a/packages/app/src/components/ContextMenuHandler.tsx
+++ b/packages/app/src/components/ContextMenuHandler.tsx
@@ -2,12 +2,14 @@ import { type FC, type ReactNode, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LuCopyPlus, LuGroup, LuScan, LuTrash } from 'react-icons/lu'
 
+import { copySelectedEntities } from '@/lib/clipboard'
 import {
   cloneSelectedEntities,
   deleteEntities,
   groupEntities,
 } from '@/lib/entities'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
+import { useEditorStore } from '@/stores/editorStore'
 
 import {
   ContextMenu,
@@ -29,6 +31,13 @@ const ContextMenuContentArea: FC = () => {
 
   return (
     <ContextMenuContent className="min-w-48 origin-top-left">
+      <ContextMenuItem
+        disabled={!someItemsSelected}
+        onClick={() => copySelectedEntities()}
+      >
+        <LuCopy /> {t(($) => $.contextMenu.copy)}
+      </ContextMenuItem>
+
       <ContextMenuItem
         disabled={!someItemsSelected}
         onClick={() => {

--- a/packages/app/src/components/ContextMenuHandler.tsx
+++ b/packages/app/src/components/ContextMenuHandler.tsx
@@ -1,8 +1,15 @@
 import { type FC, type ReactNode, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { LuCopyPlus, LuGroup, LuScan, LuTrash } from 'react-icons/lu'
+import {
+  LuClipboard,
+  LuCopy,
+  LuCopyPlus,
+  LuGroup,
+  LuScan,
+  LuTrash,
+} from 'react-icons/lu'
 
-import { copySelectedEntities } from '@/lib/clipboard'
+import { copySelectedEntities, pasteCopiedEntities } from '@/lib/clipboard'
 import {
   cloneSelectedEntities,
   deleteEntities,
@@ -29,6 +36,10 @@ const ContextMenuContentArea: FC = () => {
   )
   const someItemsSelected = selectedEntityIds.length > 0
 
+  const clipboardDataExists = useEditorStore(
+    (state) => state.clipboard.data.length > 0,
+  )
+
   return (
     <ContextMenuContent className="min-w-48 origin-top-left">
       <ContextMenuItem
@@ -36,6 +47,12 @@ const ContextMenuContentArea: FC = () => {
         onClick={() => copySelectedEntities()}
       >
         <LuCopy /> {t(($) => $.contextMenu.copy)}
+      </ContextMenuItem>
+      <ContextMenuItem
+        disabled={!clipboardDataExists}
+        onClick={() => pasteCopiedEntities()}
+      >
+        <LuClipboard /> {t(($) => $.contextMenu.paste)}
       </ContextMenuItem>
 
       <ContextMenuItem

--- a/packages/app/src/components/ShortcutHandler.tsx
+++ b/packages/app/src/components/ShortcutHandler.tsx
@@ -1,6 +1,7 @@
 import { type FC, useEffect, useMemo } from 'react'
 
 import { toggleGroup } from '@/lib/actions'
+import { copySelectedEntities, pasteCopiedEntities } from '@/lib/clipboard'
 import { cloneSelectedEntities, deleteEntities } from '@/lib/entities'
 import { openFileFromUserSelect, saveToFile } from '@/lib/file-handler'
 import { getLogger } from '@/lib/logger'
@@ -107,6 +108,12 @@ const ShortcutHandler: FC = () => {
             break
           case 'general.openSettings':
             setOpenedDialog('settings')
+            break
+          case 'general.copy':
+            copySelectedEntities()
+            break
+          case 'general.paste':
+            pasteCopiedEntities()
             break
           case 'general.undo':
             undoHistory()

--- a/packages/app/src/components/dialog/settings/ShortcutsPage.tsx
+++ b/packages/app/src/components/dialog/settings/ShortcutsPage.tsx
@@ -37,6 +37,21 @@ const ShortcutSettingsContext = createContext<{
   setCurrentlyEditingKeyId: () => {},
 })
 
+interface ShortcutKeyTextProps {
+  id: keyof Settings['shortcuts']
+}
+const ShortcutKeyText: FC<ShortcutKeyTextProps> = ({ id }) => {
+  const rawKeysStr = useEditorStore(
+    (state) => state.settings.shortcuts[id] ?? '',
+  )
+
+  return (
+    <div className="w-full max-w-48 px-2 py-1 text-neutral-300">
+      {getFormattedShortcutKeyString(rawKeysStr)}
+    </div>
+  )
+}
+
 interface ShortcutKeyInputProps {
   id: keyof Settings['shortcuts']
 }
@@ -260,6 +275,26 @@ const ShortcutsPage: FC = () => {
           {t(($) => $.dialog.settings.page.shortcuts.categories.general.title)}
         </div>
         <div className="flex flex-col">
+          <div className="mt-1 flex flex-row items-center gap-2">
+            <span className="grow px-3">
+              {t(
+                ($) =>
+                  $.dialog.settings.page.shortcuts.categories.general.items
+                    .copy,
+              )}
+            </span>
+            <ShortcutKeyText id="general.copy" />
+          </div>
+          <div className="mt-1 flex flex-row items-center gap-2">
+            <span className="grow px-3">
+              {t(
+                ($) =>
+                  $.dialog.settings.page.shortcuts.categories.general.items
+                    .paste,
+              )}
+            </span>
+            <ShortcutKeyText id="general.paste" />
+          </div>
           <div className="mt-1 flex flex-row items-center gap-2">
             <span className="grow px-3">
               {t(

--- a/packages/app/src/lib/clipboard.ts
+++ b/packages/app/src/lib/clipboard.ts
@@ -1,0 +1,11 @@
+import { useDisplayEntityStore } from '@/stores/displayEntityStore'
+import { useEditorStore } from '@/stores/editorStore'
+
+export function copySelectedEntities() {
+  const { entities, selectedEntityIds } = useDisplayEntityStore.getState()
+  const selectedEntities = selectedEntityIds
+    .map((id) => entities.get(id))
+    .filter((entity) => entity != null)
+
+  useEditorStore.getState().clipboard.setData(selectedEntities)
+}

--- a/packages/app/src/lib/clipboard.ts
+++ b/packages/app/src/lib/clipboard.ts
@@ -1,6 +1,11 @@
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
 import { useEditorStore } from '@/stores/editorStore'
 
+import { createNewEntities } from './entities'
+import { getLogger } from './logger'
+
+const logger = getLogger('clipboard')
+
 export function copySelectedEntities() {
   const { entities, selectedEntityIds } = useDisplayEntityStore.getState()
   const selectedEntities = selectedEntityIds
@@ -8,4 +13,21 @@ export function copySelectedEntities() {
     .filter((entity) => entity != null)
 
   useEditorStore.getState().clipboard.setData(selectedEntities)
+}
+
+export function pasteCopiedEntities() {
+  const { data } = useEditorStore.getState().clipboard
+  if (data.length < 1) {
+    logger.warn('Clipboard is empty, nothing to paste')
+    return
+  }
+
+  // remove `id` field because pasted entities are new entities
+  // so they should get new id
+  const payload = data.map((entity) => {
+    const { id, ...rest } = entity
+    return rest
+  })
+
+  createNewEntities(payload).catch(console.error)
 }

--- a/packages/app/src/lib/settings/prelude.ts
+++ b/packages/app/src/lib/settings/prelude.ts
@@ -9,6 +9,8 @@ export const ShortcutActions = [
   'general.openSettings',
   'general.undo',
   'general.redo',
+  'general.copy',
+  'general.paste',
   // editor
   'editor.translateMode',
   'editor.rotateMode',
@@ -19,6 +21,23 @@ export const ShortcutActions = [
 ] as const
 const ShortcutActionsZodEnum = z.enum(ShortcutActions)
 export type ShortcutActionsEnum = z.infer<typeof ShortcutActionsZodEnum>
+
+const DefaultShortcuts = {
+  // default shortcut settings
+  'general.openFromFile': 'Control o',
+  'general.saveToFile': 'Control s',
+  'general.openSettings': 'Control ,',
+  'general.undo': 'Control z',
+  'general.redo': 'Control y',
+  'general.copy': 'Control c',
+  'general.paste': 'Control v',
+  'editor.translateMode': 't',
+  'editor.rotateMode': 'r',
+  'editor.scaleMode': 's',
+  'editor.duplicate': 'd',
+  'editor.groupOrUngroup': 'g',
+  'editor.deleteEntity': 'Delete',
+} as const
 
 export const settingsSchema = z.object({
   general: z
@@ -62,21 +81,14 @@ export const settingsSchema = z.object({
   // values must be `KeyboardEvent.key` value, multiple key inputs are deliminated by space
   // key value list: https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
   shortcuts: z
-    .record(ShortcutActionsZodEnum, z.union([z.string(), z.null()]))
-    .prefault({
-      // default shortcut settings
-      'general.openFromFile': 'Control o',
-      'general.saveToFile': 'Control s',
-      'general.openSettings': 'Control ,',
-      'general.undo': 'Control z',
-      'general.redo': 'Control y',
-      'editor.translateMode': 't',
-      'editor.rotateMode': 'r',
-      'editor.scaleMode': 's',
-      'editor.duplicate': 'd',
-      'editor.groupOrUngroup': 'g',
-      'editor.deleteEntity': 'Delete',
-    }),
+    .partialRecord(ShortcutActionsZodEnum, z.union([z.string(), z.null()])) // use `.partialRecord` to ignore errors on absence of keys while preserving autocomplete
+    .prefault({})
+    .transform((data) => ({
+      // default shortcuts will be applied on each shortcut item
+      // when that item does not exist on current data
+      ...DefaultShortcuts,
+      ...data,
+    })),
   headPainter: z
     .object({
       mineskinApiKey: z.string().default(''),

--- a/packages/app/src/stores/editorStore.ts
+++ b/packages/app/src/stores/editorStore.ts
@@ -7,6 +7,7 @@ import { getLogger } from '@/lib/logger'
 import { type Settings, getStoredSettings } from '@/lib/settings/prelude'
 import type {
   DeepPartial,
+  DisplayEntity,
   Number3Tuple,
   PartialNumber3Tuple,
 } from '@/types/base'
@@ -75,6 +76,11 @@ type EditorState = {
 
   settings: Settings
   setSettings: (newSettings: DeepPartial<Settings>) => void
+
+  clipboard: {
+    data: DisplayEntity[]
+    setData: (entities: DisplayEntity[]) => void
+  }
 
   resetProject: () => void
 }
@@ -223,6 +229,15 @@ export const useEditorStore = create(
             logger.error(err)
           }
         }),
+
+      clipboard: {
+        data: [],
+        setData: (entities) =>
+          set((state) => {
+            state.clipboard.data = entities
+            console.log(entities)
+          }),
+      },
 
       resetProject: () =>
         set((state) => {


### PR DESCRIPTION
디스플레이 엔티티 복사 및 붙여넣기 기능을 추가합니다.
- 우클릭 메뉴에 복사/붙여넣기 메뉴를 추가합니다.
<img width="483" height="337" alt="image" src="https://github.com/user-attachments/assets/acab4698-d92b-467c-a059-63da42b11190" />

- Ctrl+C, Ctrl+V로도 복사 붙여넣기 기능이 작동하도록 단축키를 추가했습니다. 복사/붙여넣기 단축키를 바꾸거나 하는 경우는 거의 드물기 때문에 이 단축키는 변경이 불가능합니다.
<img width="536" height="291" alt="image" src="https://github.com/user-attachments/assets/546e669f-5b40-4228-b3ee-175ee2b7acd4" />

### 기타
- 단축키를 새로 추가하는 과정에서 새로운 단축키 데이터가 없는 이전 설정 데이터와 충돌하여 모든 설정값이 리셋되는 버그를 확인하고 수정했습니다.