### PR TITLE
perf(app): improve minecraft command generation with nbt validation

### DIFF
--- a/packages/app/public/locales/en/translation.json
+++ b/packages/app/public/locales/en/translation.json
@@ -91,7 +91,11 @@
           "options": {
             "language": "Language",
             "showWelcomeOnStartup": "Show Welcome on Startup",
-            "forceUnifont": "Force Unicode font (Unifont)"
+            "forceUnifont": "Force Unicode font (Unifont)",
+            "validateNbtInput": {
+              "title": "Validate NBT Input (Slow)",
+              "desc": "The editor will parse and validate project main NBT and per-entity NBT values, and warn if values are invalid. This may slow down command generation on large projects."
+            }
           }
         },
         "appearance": {

--- a/packages/app/public/locales/ko/translation.json
+++ b/packages/app/public/locales/ko/translation.json
@@ -91,7 +91,11 @@
           "options": {
             "language": "언어",
             "showWelcomeOnStartup": "시작 시 환영 메세지 표시",
-            "forceUnifont": "Unicode 폰트 (Unifont)를 강제로 적용"
+            "forceUnifont": "Unicode 폰트 (Unifont)를 강제로 적용",
+            "validateNbtInput": {
+              "title": "NBT 입력값 검사 (느림)",
+              "desc": "프로젝트 메인 NBT와 각 엔티티의 NBT 값을 파싱하고 검사하여, 올바르지 않은 값이 있으면 경고합니다. 대규모 프로젝트에서 명령어 생성 속도가 느려질 수 있습니다."
+            }
           }
         },
         "appearance": {

--- a/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
+++ b/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
@@ -109,7 +109,7 @@ const TagValidatorInput: FC<TagValidatorInputProps> = ({ onChange }) => {
   const { t } = useTranslation()
 
   const [input, setInput] = useState('')
-  const [debouncedInput, setDebouncedInput] = useDebouncedState('', 250)
+  const [debouncedInput, setDebouncedInput] = useDebouncedState('', 200)
   const [hasValidationErrors, setHasValidationErrors] = useState(false)
 
   useEffect(() => {

--- a/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
+++ b/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
@@ -374,7 +374,17 @@ const ExportToMinecraftDialog: FC = () => {
         </TabsList>
 
         <TabsContent value="command" className="flex min-h-0 flex-col gap-2">
-          {nbtStrings.length > 0 && (
+          {nbtDataGenerating &&
+            Array(10)
+              .fill(0)
+              .map((_, idx) => (
+                <div
+                  key={idx}
+                  className="h-8 w-full animate-pulse rounded bg-neutral-800"
+                />
+              ))}
+
+          {!nbtDataGenerating && nbtStrings.length > 0 && (
             <div className="flex gap-2">
               <Button onClick={() => downloadAsMcfunction(summonCommands)}>
                 Download summon .mcfunction
@@ -382,7 +392,7 @@ const ExportToMinecraftDialog: FC = () => {
             </div>
           )}
 
-          {nbtStrings.length < 1 && (
+          {!nbtDataGenerating && nbtStrings.length < 1 && (
             <div className="flex grow flex-col items-center justify-center gap-1 text-neutral-600">
               <LuCircleSlash size={48} className="" />
               <span className="text-center text-lg">
@@ -392,7 +402,11 @@ const ExportToMinecraftDialog: FC = () => {
           )}
 
           <div
-            className={cn('overflow-y-auto', summonCommandsExist && 'h-full')}
+            className={cn(
+              'overflow-y-auto',
+              summonCommandsExist && 'h-full',
+              nbtDataGenerating && 'hidden',
+            )}
             ref={(element) => setCommandListParentRef(element)}
           >
             <div

--- a/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
+++ b/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
@@ -379,16 +379,6 @@ const ExportToMinecraftDialog: FC = () => {
         </TabsList>
 
         <TabsContent value="command" className="flex min-h-0 flex-col gap-2">
-          {nbtDataGenerating &&
-            Array(10)
-              .fill(0)
-              .map((_, idx) => (
-                <div
-                  key={idx}
-                  className="h-8 w-full animate-pulse rounded bg-neutral-800"
-                />
-              ))}
-
           {!nbtDataGenerating && nbtStrings.length > 0 && (
             <div className="flex gap-2">
               <Button onClick={() => downloadAsMcfunction(summonCommands)}>
@@ -407,15 +397,24 @@ const ExportToMinecraftDialog: FC = () => {
           )}
 
           <div
-            className={cn(
-              'overflow-y-auto',
-              summonCommandsExist && 'h-full',
-              nbtDataGenerating && 'hidden',
-            )}
+            className={cn('overflow-y-auto', summonCommandsExist && 'h-full')}
             ref={(element) => setCommandListParentRef(element)}
           >
+            {nbtDataGenerating && (
+              <div className="flex flex-col gap-2">
+                {Array(10)
+                  .fill(0)
+                  .map((_, idx) => (
+                    <div
+                      key={idx}
+                      className="h-8 w-full animate-pulse rounded bg-neutral-800"
+                    />
+                  ))}
+              </div>
+            )}
+
             <div
-              className="relative w-full"
+              className={cn('relative w-full', nbtDataGenerating && 'hidden')}
               style={{
                 height: virtualizer.getTotalSize(),
               }}

--- a/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
+++ b/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
@@ -1,11 +1,11 @@
 import { useDebouncedEffect } from '@react-hookz/web'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import JSZip from 'jszip'
-import mojangson, { type MojangsonList } from 'mojangson'
 import {
   type ComponentPropsWithoutRef,
   type FC,
   useEffect,
+  useRef,
   useState,
 } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
@@ -15,24 +15,20 @@ import {
   LuCopy,
   LuCopyCheck,
 } from 'react-icons/lu'
-import { coerce as semverCoerce, satisfies as semverSatisfies } from 'semver'
 import { toast } from 'sonner'
 import { useShallow } from 'zustand/shallow'
 
 import { GameVersions } from '@/constants'
-import { getLogger } from '@/lib/logger'
-import { validateSNBT } from '@/lib/nbt'
 import { cn, downloadFile } from '@/lib/utils'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
 import { useEntityRefStore } from '@/stores/entityRefStore'
 import { useProjectStore } from '@/stores/projectStore'
 import type {
-  DisplayEntity,
-  MinimalTextureValue,
-  TextEffects,
-} from '@/types/base'
-import { isItemDisplayPlayerHead } from '@/types/guards'
+  ExportedNBTGeneratorWorkerMessage,
+  ExportedNBTGeneratorWorkerMessage_GeneratePayload,
+  ExportedNBTGeneratorWorkerResponse,
+} from '@/types/workers'
 
 import { Button } from '../ui/button'
 import {
@@ -49,10 +45,6 @@ import { Input } from '../ui/input'
 import { Switch } from '../ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
 import Dialog from './Dialog'
-
-const logger = getLogger('ExportToMinecraftDialog')
-
-const COMMAND_BLOCK_MAX_COMMAND_LENGTH = 32500
 
 type CopyButtonProps = ComponentPropsWithoutRef<'button'> & {
   valueToCopy: string
@@ -235,35 +227,80 @@ const ExportToMinecraftDialog: FC = () => {
   )
 
   const [baseTag, setBaseTag] = useState('')
-  const [nbtDataGenerated, setNbtDataGenerated] = useState(false)
+  const [nbtDataGenerating, setNbtDataGenerating] = useState(false)
   const [nbtDataValid, setNbtDataValid] = useState(true)
   const [nbtStrings, setNbtStrings] = useState<string[]>([])
+
+  const nbtGeneratorWorkerRef = useRef<Worker>()
+  useEffect(() => {
+    // TODO: make it suspend using `use()` after react v19 upgrade
+    if (isOpen) {
+      if (entities.size < 1) {
+        setNbtDataGenerating(false)
+        return
+      }
+
+      nbtGeneratorWorkerRef.current = new Worker(
+        new URL(
+          '../../workers/exportedNbtGenerator.worker.ts',
+          import.meta.url,
+        ),
+        { type: 'module' },
+      )
+
+      setNbtDataGenerating(true)
+
+      const { entityRefs } = useEntityRefStore.getState()
+      const payload = [...entities.values()].reduce((acc, cur) => {
+        const refData = entityRefs.get(cur.id)
+        if (refData != null) {
+          const worldMatrix = refData.objectRef.current.matrixWorld
+            .clone()
+            .transpose()
+            .toArray()
+          acc.set(cur.id, {
+            entity: cur,
+            worldMatrix,
+          })
+        }
+
+        return acc
+      }, new Map<string, ExportedNBTGeneratorWorkerMessage_GeneratePayload>())
+
+      nbtGeneratorWorkerRef.current?.addEventListener(
+        'message',
+        (evt: MessageEvent<ExportedNBTGeneratorWorkerResponse>) => {
+          const msg = evt.data
+
+          if (msg.type === 'data') {
+            setNbtStrings(msg.data.nbtStrings)
+            setNbtDataGenerating(false)
+            setNbtDataValid(!msg.data.invalidNBTExist)
+          }
+        },
+      )
+
+      nbtGeneratorWorkerRef.current?.postMessage({
+        cmd: 'generate',
+        data: {
+          payload,
+          targetGameVersion,
+          baseTag,
+          mainNBT,
+        },
+      } satisfies ExportedNBTGeneratorWorkerMessage)
+    }
+
+    return () => {
+      nbtGeneratorWorkerRef.current?.terminate()
+    }
+  }, [isOpen, entities, targetGameVersion, baseTag, mainNBT]) // 엔티티 데이터나 태그가 바뀌었다면 커맨드를 다시 생성해야 함
 
   useEffect(() => {
     if (isOpen) {
       setBaseTag('')
     }
   }, [isOpen])
-
-  // 엔티티 데이터나 태그가 바뀌었다면 커맨드를 다시 생성해야 함
-  useEffect(() => {
-    setNbtDataGenerated(false)
-  }, [entities, baseTag, mainNBT, targetGameVersion])
-
-  useEffect(() => {
-    if (!nbtDataGenerated && isOpen) {
-      const { nbtStrings, invalidNBTExist } = generateNbtStrings(
-        entities,
-        targetGameVersion,
-        baseTag,
-        mainNBT,
-      )
-
-      setNbtStrings(nbtStrings)
-      setNbtDataGenerated(true)
-      setNbtDataValid(!invalidNBTExist)
-    }
-  }, [nbtDataGenerated, isOpen, baseTag, mainNBT, entities, targetGameVersion])
 
   const summonCommands = nbtStrings.map(
     (nbt) => `/summon block_display ~ ~ ~ ${nbt}`,
@@ -507,228 +544,6 @@ const ExportToMinecraftDialog: FC = () => {
       </Tabs>
     </Dialog>
   )
-}
-
-function generateNbtStrings(
-  entities: Map<string, DisplayEntity>,
-  targetGameVersion: string,
-  baseTag: string = '',
-  mainNBT: string = '',
-): {
-  nbtStrings: string[]
-  invalidNBTExist: boolean
-} {
-  const { entityRefs } = useEntityRefStore.getState()
-
-  let invalidNBTExist = false
-
-  const semveredGameVersion = semverCoerce(targetGameVersion)?.version
-  if (semveredGameVersion == null) {
-    throw new Error('semveredGameVersion is null, this should not happen')
-  }
-
-  // whether item uses data component instead of nbt
-  const isItemDataComponentEnabled = semverSatisfies(
-    semveredGameVersion,
-    '>=1.20.5',
-  )
-  // whether text is represented as SNBT rather than JSON
-  const isTextFormatSNBT = semverSatisfies(semveredGameVersion, '>=1.21.5')
-
-  // =====
-
-  // validate mainNBT and inject baseTag first
-  if (validateSNBT(mainNBT) == null) {
-    invalidNBTExist = true
-  }
-  const tagInjectedMainNBT = injectBaseTag(mainNBT, baseTag, false)
-
-  const passengersStrings = [...entities.values()]
-    .map((entity) => {
-      // 그룹은 커맨드 생성에 들어가지 않음
-      // 그룹 안에 있는 엔티티들은 world transform으로 반영됨
-      if (entity.kind === 'group') return
-
-      const refData = entityRefs.get(entity.id)
-      if (refData == null || refData.objectRef.current == null) {
-        logger.warn(`entity ref of entity ${entity.id} not found, ignoring.`)
-        return
-      }
-
-      const worldMatrix = refData.objectRef.current.matrixWorld
-
-      const idText = entity.kind + '_display' // block_display, item_display, text_display
-      const transformationString = worldMatrix
-        .clone()
-        .transpose()
-        .toArray()
-        .map((num) => Math.round(num * 1_0000_0000) / 1_0000_0000 + 'f')
-        .join(',')
-
-      let specificData = ''
-      if (entity.kind === 'block') {
-        const propertiesText = Object.entries(entity.blockstates)
-          .map(([k, v]) => `${k}:"${v}"`)
-          .join(',')
-
-        specificData = `block_state:{Name:"${entity.type}",Properties:{${propertiesText}}}`
-      } else if (entity.kind === 'item') {
-        const displayText =
-          entity.display != null ? `,item_display:"${entity.display}"` : ''
-
-        let itemExtraData = ''
-        if (isItemDisplayPlayerHead(entity)) {
-          const textureData = entity.playerHeadProperties.texture
-          if (textureData?.baked) {
-            const o = {
-              textures: {
-                SKIN: {
-                  url: textureData.url,
-                },
-              },
-            } satisfies MinimalTextureValue
-            const textureValueString = btoa(JSON.stringify(o))
-            itemExtraData = isItemDataComponentEnabled
-              ? `,components:{"minecraft:profile":{properties:[{name:"textures",value:"${textureValueString}"}]}}`
-              : `,SkullOwner:{Properties:{textures:[{Value:"${textureValueString}"}]}}`
-          }
-        }
-        specificData = `item:{id:"${entity.type}"${itemExtraData}}${displayText}`
-      } else if (entity.kind === 'text') {
-        // text
-        const text = entity.text
-          .replaceAll('\\', '\\\\')
-          .replaceAll('\n', isTextFormatSNBT ? '\\n' : '\\\\n')
-          .replaceAll('"', '\\"')
-        const enabledTextEffects = (
-          Object.keys(entity.textEffects) as Array<keyof TextEffects>
-        ).filter((k) => entity.textEffects[k])
-        const enabledTextEffectsString =
-          enabledTextEffects.length > 0
-            ? ',' +
-              enabledTextEffects
-                .map((k) => (isTextFormatSNBT ? `${k}:true` : `"${k}":true`))
-                .join(',')
-            : ''
-        specificData = isTextFormatSNBT
-          ? `text:{text:"${text}"${enabledTextEffectsString},color:"#${entity.textColor.toString(16)}"}`
-          : `text:'{"text":"${text}"${enabledTextEffectsString},"color":"#${entity.textColor.toString(16)}"}'`
-
-        // TODO: omit optional nbt data if data value is default value
-
-        // alignment
-        specificData += `,alignment:"${entity.alignment}"`
-        // background_color
-        specificData += `,background_color:${entity.backgroundColor}`
-        // default_background
-        if (entity.defaultBackground) {
-          specificData += ',default_background:true'
-        }
-        // line_width
-        specificData += `,line_width:${entity.lineWidth}`
-        // see_through
-        if (entity.seeThrough) {
-          specificData += ',see_through:true'
-        }
-        // shadow
-        if (entity.shadow) {
-          specificData += ',shadow:true'
-        }
-        // text_opacity
-        specificData += `,text_opacity:${entity.textOpacity}`
-      }
-
-      const generatedString = `{id:"${idText}",${specificData},transformation:[${transformationString}]${entity.nbt.length > 0 ? ',' + entity.nbt : ''}}`
-
-      if (validateSNBT(generatedString) == null) {
-        invalidNBTExist = true
-      }
-
-      // attempt to inject baseTag
-      const finalString = injectBaseTag(generatedString, baseTag, true)
-      if (finalString == null) {
-        return generatedString
-      }
-
-      return finalString
-    })
-    .filter((d) => d != null)
-
-  let le = Infinity
-  const baseCommandLength =
-    `/summon block_display ~ ~ ~ {${tagInjectedMainNBT},Passengers:[]}`.length
-  const groupedPassengersStrings: string[] = []
-  for (const passengersStr of passengersStrings) {
-    if (
-      baseCommandLength + le + passengersStr.length <=
-      COMMAND_BLOCK_MAX_COMMAND_LENGTH
-    ) {
-      // split to another summon command if adding up to current entity nbt data
-      // overflows the 32500 command block command max length
-      groupedPassengersStrings[groupedPassengersStrings.length - 1] +=
-        ',' + passengersStr
-      le += passengersStr.length + 1 // length including leading `,`
-    } else {
-      // if adding up to current entity nbt data does not overflow the limit
-      // then just add to the last summon command
-      groupedPassengersStrings.push(passengersStr)
-      le = passengersStr.length
-    }
-  }
-
-  if (validateSNBT(mainNBT) == null) {
-    invalidNBTExist = true
-  }
-
-  const newNbtStrings = groupedPassengersStrings.map((str) => {
-    const inner = [tagInjectedMainNBT, `Passengers:[${str}]`]
-      .filter((str) => str != null && str.length > 0)
-      .join(',')
-    return '{' + inner + '}'
-  })
-
-  return {
-    nbtStrings: newNbtStrings,
-    invalidNBTExist,
-  }
-}
-
-function injectBaseTag(
-  nbtString: string,
-  baseTag: string,
-  wrapWithBraces = false,
-) {
-  // If baseTag is empty, do nothing
-  if (baseTag.length < 1) return nbtString
-  // If nbt string is empty, create a new one
-  if (nbtString.length < 1) {
-    const tagString = `Tags:["${baseTag}"]`
-    return wrapWithBraces ? `{${tagString}}` : tagString
-  }
-
-  const parsedData = validateSNBT(nbtString)
-  if (parsedData?.type !== 'compound') {
-    // logger.error(
-    //   'Failed to parse entity nbt string. Root element type is not `compound`.',
-    // )
-    return null
-  }
-
-  const tagListNode = parsedData.value['Tags']
-  if (tagListNode?.type !== 'list') {
-    parsedData.value['Tags'] = {
-      type: 'list',
-      value: {
-        type: 'string',
-        value: [baseTag],
-      },
-    } satisfies MojangsonList
-  } else {
-    tagListNode.value.value.push(baseTag)
-  }
-
-  const injected = mojangson.stringify(parsedData)
-  return wrapWithBraces ? injected : injected.slice(1, -1)
 }
 
 function downloadAsMcfunction(commands: string[]) {

--- a/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
+++ b/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
@@ -1,7 +1,7 @@
 import { useDebouncedEffect } from '@react-hookz/web'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import JSZip from 'jszip'
-import mojangson, { type MojangsonList } from 'mojangson'
+import mojangson, { type MojangsonList, type MojangsonNode } from 'mojangson'
 import {
   type ComponentPropsWithoutRef,
   type FC,
@@ -538,10 +538,12 @@ function generateNbtStrings(
   // =====
 
   // validate mainNBT and inject baseTag first
-  if (validateSNBT(mainNBT) == null) {
+  const mainNbtTree = validateSNBT(mainNBT)
+  if (mainNbtTree == null) {
     invalidNBTExist = true
   }
-  const tagInjectedMainNBT = injectBaseTag(mainNBT, baseTag, false)
+  const tagInjectedMainNBT =
+    mainNbtTree != null ? injectBaseTag(mainNbtTree, baseTag, false) : mainNBT
 
   const passengersStrings = [...entities.values()]
     .map((entity) => {
@@ -640,12 +642,14 @@ function generateNbtStrings(
 
       const generatedString = `{id:"${idText}",${specificData},transformation:[${transformationString}]${entity.nbt.length > 0 ? ',' + entity.nbt : ''}}`
 
-      if (validateSNBT(generatedString) == null) {
+      const nbtTree = validateSNBT(generatedString)
+      if (nbtTree == null) {
         invalidNBTExist = true
+        return generatedString
       }
 
       // attempt to inject baseTag
-      const finalString = injectBaseTag(generatedString, baseTag, true)
+      const finalString = injectBaseTag(nbtTree, baseTag, true)
       if (finalString == null) {
         return generatedString
       }
@@ -676,10 +680,6 @@ function generateNbtStrings(
     }
   }
 
-  if (validateSNBT(mainNBT) == null) {
-    invalidNBTExist = true
-  }
-
   const newNbtStrings = groupedPassengersStrings.map((str) => {
     const inner = [tagInjectedMainNBT, `Passengers:[${str}]`]
       .filter((str) => str != null && str.length > 0)
@@ -694,40 +694,33 @@ function generateNbtStrings(
 }
 
 function injectBaseTag(
-  nbtString: string,
+  nbtTree: MojangsonNode,
   baseTag: string,
   wrapWithBraces = false,
 ) {
-  // If baseTag is empty, do nothing
-  if (baseTag.length < 1) return nbtString
-  // If nbt string is empty, create a new one
-  if (nbtString.length < 1) {
-    const tagString = `Tags:["${baseTag}"]`
-    return wrapWithBraces ? `{${tagString}}` : tagString
-  }
-
-  const parsedData = validateSNBT(nbtString)
-  if (parsedData?.type !== 'compound') {
+  if (nbtTree.type !== 'compound') {
     // logger.error(
     //   'Failed to parse entity nbt string. Root element type is not `compound`.',
     // )
     return null
   }
 
-  const tagListNode = parsedData.value['Tags']
-  if (tagListNode?.type !== 'list') {
-    parsedData.value['Tags'] = {
-      type: 'list',
-      value: {
-        type: 'string',
-        value: [baseTag],
-      },
-    } satisfies MojangsonList
-  } else {
-    tagListNode.value.value.push(baseTag)
+  if (baseTag.length > 0) {
+    const tagListNode = nbtTree.value['Tags']
+    if (tagListNode?.type !== 'list') {
+      nbtTree.value['Tags'] = {
+        type: 'list',
+        value: {
+          type: 'string',
+          value: [baseTag],
+        },
+      } satisfies MojangsonList
+    } else {
+      tagListNode.value.value.push(baseTag)
+    }
   }
 
-  const injected = mojangson.stringify(parsedData)
+  const injected = mojangson.stringify(nbtTree)
   return wrapWithBraces ? injected : injected.slice(1, -1)
 }
 

--- a/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
+++ b/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
@@ -25,6 +25,7 @@ import { validateSNBT } from '@/lib/nbt'
 import { cn, downloadFile } from '@/lib/utils'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
+import { useEditorStore } from '@/stores/editorStore'
 import { useEntityRefStore } from '@/stores/entityRefStore'
 import { useProjectStore } from '@/stores/projectStore'
 import type {
@@ -251,13 +252,17 @@ const ExportToMinecraftDialog: FC = () => {
   }, [entities, baseTag, mainNBT, targetGameVersion])
 
   useEffect(() => {
+    const nbtValidationEnabled =
+      useEditorStore.getState().settings.general.validateNbtInput
+
     if (!nbtDataGenerated && isOpen) {
-      const { nbtStrings, invalidNBTExist } = generateNbtStrings(
+      const { nbtStrings, invalidNBTExist } = generateNbtStrings({
         entities,
         targetGameVersion,
         baseTag,
         mainNBT,
-      )
+        validateNBT: nbtValidationEnabled,
+      })
 
       setNbtStrings(nbtStrings)
       setNbtDataGenerated(true)
@@ -509,12 +514,19 @@ const ExportToMinecraftDialog: FC = () => {
   )
 }
 
-function generateNbtStrings(
-  entities: Map<string, DisplayEntity>,
-  targetGameVersion: string,
-  baseTag: string = '',
-  mainNBT: string = '',
-): {
+function generateNbtStrings({
+  entities,
+  targetGameVersion,
+  baseTag = '',
+  mainNBT = '',
+  validateNBT = false,
+}: {
+  entities: Map<string, DisplayEntity>
+  targetGameVersion: string
+  baseTag: string
+  mainNBT: string
+  validateNBT: boolean
+}): {
   nbtStrings: string[]
   invalidNBTExist: boolean
 } {
@@ -538,12 +550,17 @@ function generateNbtStrings(
   // =====
 
   // validate mainNBT and inject baseTag first
-  const mainNbtTree = validateSNBT(mainNBT)
-  if (mainNbtTree == null) {
-    invalidNBTExist = true
+  let tagInjectedMainNBT = null
+  if (validateNBT) {
+    const mainNbtTree = validateSNBT(mainNBT)
+    if (mainNbtTree == null) {
+      invalidNBTExist = true
+    }
+    tagInjectedMainNBT =
+      mainNbtTree != null ? injectBaseTag(mainNbtTree, baseTag, false) : mainNBT
+  } else {
+    tagInjectedMainNBT = injectBaseTagSimple(mainNBT, baseTag, false)
   }
-  const tagInjectedMainNBT =
-    mainNbtTree != null ? injectBaseTag(mainNbtTree, baseTag, false) : mainNBT
 
   const passengersStrings = [...entities.values()]
     .map((entity) => {
@@ -642,19 +659,24 @@ function generateNbtStrings(
 
       const generatedString = `{id:"${idText}",${specificData},transformation:[${transformationString}]${entity.nbt.length > 0 ? ',' + entity.nbt : ''}}`
 
-      const nbtTree = validateSNBT(generatedString)
-      if (nbtTree == null) {
-        invalidNBTExist = true
-        return generatedString
-      }
+      if (validateNBT) {
+        const nbtTree = validateSNBT(generatedString)
+        if (nbtTree == null) {
+          invalidNBTExist = true
+          return generatedString
+        }
 
-      // attempt to inject baseTag
-      const finalString = injectBaseTag(nbtTree, baseTag, true)
-      if (finalString == null) {
-        return generatedString
-      }
+        // attempt to inject baseTag
+        const finalString = injectBaseTag(nbtTree, baseTag, true)
+        if (finalString == null) {
+          return generatedString
+        }
 
-      return finalString
+        return finalString
+      } else {
+        const finalString = injectBaseTagSimple(generatedString, baseTag, true)
+        return finalString
+      }
     })
     .filter((d) => d != null)
 
@@ -693,6 +715,22 @@ function generateNbtStrings(
   }
 }
 
+function injectBaseTagSimple(
+  nbtString: string,
+  baseTag: string,
+  wrapWithBraces = false,
+) {
+  if (nbtString.startsWith('{')) nbtString = nbtString.slice(1)
+  if (nbtString.endsWith('}')) nbtString = nbtString.slice(0, -1)
+
+  if (baseTag.length < 1) {
+    return wrapWithBraces ? nbtString : nbtString.slice(1, -1)
+  }
+
+  const injected =
+    '{' + (nbtString.length > 0 ? `${nbtString},` : '') + `Tags:["${baseTag}"]}`
+  return wrapWithBraces ? injected : injected.slice(1, -1)
+}
 function injectBaseTag(
   nbtTree: MojangsonNode,
   baseTag: string,

--- a/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
+++ b/packages/app/src/components/dialog/ExportToMinecraftDialog.tsx
@@ -1,4 +1,4 @@
-import { useDebouncedEffect } from '@react-hookz/web'
+import { useDebouncedEffect, useDebouncedState } from '@react-hookz/web'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import JSZip from 'jszip'
 import {
@@ -109,7 +109,12 @@ const TagValidatorInput: FC<TagValidatorInputProps> = ({ onChange }) => {
   const { t } = useTranslation()
 
   const [input, setInput] = useState('')
+  const [debouncedInput, setDebouncedInput] = useDebouncedState('', 250)
   const [hasValidationErrors, setHasValidationErrors] = useState(false)
+
+  useEffect(() => {
+    onChange?.(debouncedInput)
+  }, [debouncedInput, onChange])
 
   return (
     <Field data-invalid={hasValidationErrors}>
@@ -124,7 +129,7 @@ const TagValidatorInput: FC<TagValidatorInputProps> = ({ onChange }) => {
 
           if (/^[a-z0-9_\-.+]*$/gi.test(text)) {
             setHasValidationErrors(false)
-            onChange?.(text)
+            setDebouncedInput(text)
           } else {
             setHasValidationErrors(true)
           }

--- a/packages/app/src/components/dialog/settings/GeneralPage.tsx
+++ b/packages/app/src/components/dialog/settings/GeneralPage.tsx
@@ -4,7 +4,13 @@ import { toast } from 'sonner'
 import { useShallow } from 'zustand/shallow'
 
 import { Button } from '@/components/ui/button'
-import { Field, FieldGroup, FieldLabel } from '@/components/ui/field'
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from '@/components/ui/field'
 import { NativeSelect, NativeSelectOption } from '@/components/ui/native-select'
 import { Switch } from '@/components/ui/switch'
 import { exportSettings, importSettings } from '@/lib/settings/actions'
@@ -76,6 +82,32 @@ const GeneralPage: FC = () => {
             onCheckedChange={(checked) => {
               setSettings({
                 general: { forceUnifont: checked },
+              })
+            }}
+          />
+        </Field>
+
+        <Field orientation="horizontal">
+          <FieldContent>
+            <FieldLabel htmlFor="settings_general_validateNbtInput">
+              {t(
+                ($) =>
+                  $.dialog.settings.page.general.options.validateNbtInput.title,
+              )}
+            </FieldLabel>
+            <FieldDescription>
+              {t(
+                ($) =>
+                  $.dialog.settings.page.general.options.validateNbtInput.desc,
+              )}
+            </FieldDescription>
+          </FieldContent>
+          <Switch
+            id="settings_general_validateNbtInput"
+            checked={settings.general.validateNbtInput}
+            onCheckedChange={(checked) => {
+              setSettings({
+                general: { validateNbtInput: checked },
               })
             }}
           />

--- a/packages/app/src/components/sidebar/PropertiesPanel.tsx
+++ b/packages/app/src/components/sidebar/PropertiesPanel.tsx
@@ -24,6 +24,7 @@ import { validateSNBT } from '@/lib/nbt'
 import { cn, isValidTextureUrl } from '@/lib/utils'
 import { useDialogStore } from '@/stores/dialogStore'
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
+import { useEditorStore } from '@/stores/editorStore'
 import { useHistoryStore } from '@/stores/historyStore'
 import { useProjectStore } from '@/stores/projectStore'
 import type {
@@ -560,8 +561,14 @@ const ProjectProperties: FC = () => {
       setMainNBT: state.setMainNBT,
     })),
   )
+  const nbtValidationEnabled = useEditorStore(
+    (state) => state.settings.general.validateNbtInput,
+  )
 
-  const mainNBTValid = useMemo(() => validateSNBT(mainNBT) != null, [mainNBT])
+  const mainNBTValid = useMemo(
+    () => (nbtValidationEnabled ? validateSNBT(mainNBT) != null : true),
+    [mainNBT, nbtValidationEnabled],
+  )
 
   return (
     <div className="flex flex-col gap-2">
@@ -688,10 +695,16 @@ const CommonDisplayProperties: FC = () => {
         : null
     return entity
   })
+  const nbtValidationEnabled = useEditorStore(
+    (state) => state.settings.general.validateNbtInput,
+  )
 
   const nbtValid = useMemo(
-    () => validateSNBT(singleSelectedEntity?.nbt ?? '') != null,
-    [singleSelectedEntity?.nbt],
+    () =>
+      nbtValidationEnabled
+        ? validateSNBT(singleSelectedEntity?.nbt ?? '') != null
+        : true,
+    [singleSelectedEntity?.nbt, nbtValidationEnabled],
   )
 
   if (singleSelectedEntity == null) return null

--- a/packages/app/src/constants.ts
+++ b/packages/app/src/constants.ts
@@ -74,3 +74,5 @@ export const GameVersions = [
 ]
 export const LegacyHardcodedGameVersion = '1.21'
 export const LatestGameVersion = GameVersions[0].id
+
+export const CommandBlockMaxCommandLength = 32500

--- a/packages/app/src/lib/nbt.ts
+++ b/packages/app/src/lib/nbt.ts
@@ -229,7 +229,7 @@ function injectBaseTagSimple(
   if (nbtString.endsWith('}')) nbtString = nbtString.slice(0, -1)
 
   if (baseTag.length < 1) {
-    return wrapWithBraces ? nbtString : nbtString.slice(1, -1)
+    return wrapWithBraces ? `{${nbtString}}` : nbtString
   }
 
   const injected =

--- a/packages/app/src/lib/nbt.ts
+++ b/packages/app/src/lib/nbt.ts
@@ -1,4 +1,10 @@
-import mojangson from 'mojangson'
+import mojangson, { type MojangsonList } from 'mojangson'
+import { coerce as semverCoerce, satisfies as semverSatisfies } from 'semver'
+
+import { CommandBlockMaxCommandLength } from '@/constants'
+import type { MinimalTextureValue, TextEffects } from '@/types/base'
+import { isItemDisplayPlayerHead } from '@/types/guards'
+import type { ExportedNBTGeneratorWorkerMessage_GeneratePayload } from '@/types/workers'
 
 export function validateSNBT(input: string) {
   // If nbt string does not wrapped with curly brackets, wrap it
@@ -16,4 +22,218 @@ export function validateSNBT(input: string) {
   } catch {
     return null
   }
+}
+
+export function generateNbtStrings({
+  payload,
+  targetGameVersion,
+  baseTag = '',
+  mainNBT = '',
+}: {
+  payload: Map<string, ExportedNBTGeneratorWorkerMessage_GeneratePayload>
+  targetGameVersion: string
+  baseTag: string
+  mainNBT: string
+}): {
+  nbtStrings: string[]
+  invalidNBTExist: boolean
+} {
+  let invalidNBTExist = false
+
+  const semveredGameVersion = semverCoerce(targetGameVersion)?.version
+  if (semveredGameVersion == null) {
+    throw new Error('semveredGameVersion is null, this should not happen')
+  }
+
+  // whether item uses data component instead of nbt
+  const isItemDataComponentEnabled = semverSatisfies(
+    semveredGameVersion,
+    '>=1.20.5',
+  )
+  // whether text is represented as SNBT rather than JSON
+  const isTextFormatSNBT = semverSatisfies(semveredGameVersion, '>=1.21.5')
+
+  // =====
+
+  // validate mainNBT and inject baseTag first
+  if (validateSNBT(mainNBT) == null) {
+    invalidNBTExist = true
+  }
+  const tagInjectedMainNBT = injectBaseTag(mainNBT, baseTag, false)
+
+  const passengersStrings = [...payload.values()]
+    .map(({ entity, worldMatrix }) => {
+      // 그룹은 커맨드 생성에 들어가지 않음
+      // 그룹 안에 있는 엔티티들은 world transform으로 반영됨
+      if (entity.kind === 'group') return
+
+      const idText = entity.kind + '_display' // block_display, item_display, text_display
+      const transformationString = worldMatrix
+        .map((num) => Math.round(num * 1_0000_0000) / 1_0000_0000 + 'f')
+        .join(',')
+
+      let specificData = ''
+      if (entity.kind === 'block') {
+        const propertiesText = Object.entries(entity.blockstates)
+          .map(([k, v]) => `${k}:"${v}"`)
+          .join(',')
+
+        specificData = `block_state:{Name:"${entity.type}",Properties:{${propertiesText}}}`
+      } else if (entity.kind === 'item') {
+        const displayText =
+          entity.display != null ? `,item_display:"${entity.display}"` : ''
+
+        let itemExtraData = ''
+        if (isItemDisplayPlayerHead(entity)) {
+          const textureData = entity.playerHeadProperties.texture
+          if (textureData?.baked) {
+            const o = {
+              textures: {
+                SKIN: {
+                  url: textureData.url,
+                },
+              },
+            } satisfies MinimalTextureValue
+            const textureValueString = btoa(JSON.stringify(o))
+            itemExtraData = isItemDataComponentEnabled
+              ? `,components:{"minecraft:profile":{properties:[{name:"textures",value:"${textureValueString}"}]}}`
+              : `,SkullOwner:{Properties:{textures:[{Value:"${textureValueString}"}]}}`
+          }
+        }
+        specificData = `item:{id:"${entity.type}"${itemExtraData}}${displayText}`
+      } else if (entity.kind === 'text') {
+        // text
+        const text = entity.text
+          .replaceAll('\\', '\\\\')
+          .replaceAll('\n', isTextFormatSNBT ? '\\n' : '\\\\n')
+          .replaceAll('"', '\\"')
+        const enabledTextEffects = (
+          Object.keys(entity.textEffects) as Array<keyof TextEffects>
+        ).filter((k) => entity.textEffects[k])
+        const enabledTextEffectsString =
+          enabledTextEffects.length > 0
+            ? ',' +
+              enabledTextEffects
+                .map((k) => (isTextFormatSNBT ? `${k}:true` : `"${k}":true`))
+                .join(',')
+            : ''
+        specificData = isTextFormatSNBT
+          ? `text:{text:"${text}"${enabledTextEffectsString},color:"#${entity.textColor.toString(16)}"}`
+          : `text:'{"text":"${text}"${enabledTextEffectsString},"color":"#${entity.textColor.toString(16)}"}'`
+
+        // TODO: omit optional nbt data if data value is default value
+
+        // alignment
+        specificData += `,alignment:"${entity.alignment}"`
+        // background_color
+        specificData += `,background_color:${entity.backgroundColor}`
+        // default_background
+        if (entity.defaultBackground) {
+          specificData += ',default_background:true'
+        }
+        // line_width
+        specificData += `,line_width:${entity.lineWidth}`
+        // see_through
+        if (entity.seeThrough) {
+          specificData += ',see_through:true'
+        }
+        // shadow
+        if (entity.shadow) {
+          specificData += ',shadow:true'
+        }
+        // text_opacity
+        specificData += `,text_opacity:${entity.textOpacity}`
+      }
+
+      const generatedString = `{id:"${idText}",${specificData},transformation:[${transformationString}]${entity.nbt.length > 0 ? ',' + entity.nbt : ''}}`
+
+      if (validateSNBT(generatedString) == null) {
+        invalidNBTExist = true
+      }
+
+      // attempt to inject baseTag
+      const finalString = injectBaseTag(generatedString, baseTag, true)
+      if (finalString == null) {
+        return generatedString
+      }
+
+      return finalString
+    })
+    .filter((d) => d != null)
+
+  let le = Infinity
+  const baseCommandLength =
+    `/summon block_display ~ ~ ~ {${tagInjectedMainNBT},Passengers:[]}`.length
+  const groupedPassengersStrings: string[] = []
+  for (const passengersStr of passengersStrings) {
+    if (
+      baseCommandLength + le + passengersStr.length <=
+      CommandBlockMaxCommandLength
+    ) {
+      // split to another summon command if adding up to current entity nbt data
+      // overflows the 32500 command block command max length
+      groupedPassengersStrings[groupedPassengersStrings.length - 1] +=
+        ',' + passengersStr
+      le += passengersStr.length + 1 // length including leading `,`
+    } else {
+      // if adding up to current entity nbt data does not overflow the limit
+      // then just add to the last summon command
+      groupedPassengersStrings.push(passengersStr)
+      le = passengersStr.length
+    }
+  }
+
+  if (validateSNBT(mainNBT) == null) {
+    invalidNBTExist = true
+  }
+
+  const newNbtStrings = groupedPassengersStrings.map((str) => {
+    const inner = [tagInjectedMainNBT, `Passengers:[${str}]`]
+      .filter((str) => str != null && str.length > 0)
+      .join(',')
+    return '{' + inner + '}'
+  })
+
+  return {
+    nbtStrings: newNbtStrings,
+    invalidNBTExist,
+  }
+}
+
+function injectBaseTag(
+  nbtString: string,
+  baseTag: string,
+  wrapWithBraces = false,
+) {
+  // If baseTag is empty, do nothing
+  if (baseTag.length < 1) return nbtString
+  // If nbt string is empty, create a new one
+  if (nbtString.length < 1) {
+    const tagString = `Tags:["${baseTag}"]`
+    return wrapWithBraces ? `{${tagString}}` : tagString
+  }
+
+  const parsedData = validateSNBT(nbtString)
+  if (parsedData?.type !== 'compound') {
+    // logger.error(
+    //   'Failed to parse entity nbt string. Root element type is not `compound`.',
+    // )
+    return null
+  }
+
+  const tagListNode = parsedData.value['Tags']
+  if (tagListNode?.type !== 'list') {
+    parsedData.value['Tags'] = {
+      type: 'list',
+      value: {
+        type: 'string',
+        value: [baseTag],
+      },
+    } satisfies MojangsonList
+  } else {
+    tagListNode.value.value.push(baseTag)
+  }
+
+  const injected = mojangson.stringify(parsedData)
+  return wrapWithBraces ? injected : injected.slice(1, -1)
 }

--- a/packages/app/src/lib/settings/prelude.ts
+++ b/packages/app/src/lib/settings/prelude.ts
@@ -45,6 +45,7 @@ export const settingsSchema = z.object({
       language: z.enum(['en', 'ko']).default('en'),
       showWelcomeOnStartup: z.boolean().default(true),
       forceUnifont: z.boolean().default(false),
+      validateNbtInput: z.boolean().default(false),
     })
     .prefault({}),
   appearance: z

--- a/packages/app/src/types/workers.ts
+++ b/packages/app/src/types/workers.ts
@@ -1,3 +1,8 @@
+// headBaker
+import type { Matrix4Tuple } from 'three'
+
+import type { DisplayEntity } from './base'
+
 export type HeadBakerJob = {
   jobId?: string
   entityId: string
@@ -64,3 +69,27 @@ export type HeadBakerWorkerResponse =
           }
       ))[]
     }
+
+// exportedNbtGenerator
+export type ExportedNBTGeneratorWorkerMessage_GeneratePayload = {
+  entity: DisplayEntity
+  worldMatrix: Matrix4Tuple // row-major world matrix of that entity
+}
+
+export interface ExportedNBTGeneratorWorkerMessage {
+  cmd: 'generate'
+  data: {
+    payload: Map<string, ExportedNBTGeneratorWorkerMessage_GeneratePayload>
+    targetGameVersion: string
+    baseTag: string
+    mainNBT: string
+  }
+}
+
+export interface ExportedNBTGeneratorWorkerResponse {
+  type: 'data'
+  data: {
+    nbtStrings: string[]
+    invalidNBTExist: boolean
+  }
+}

--- a/packages/app/src/workers/exportedNbtGenerator.worker.ts
+++ b/packages/app/src/workers/exportedNbtGenerator.worker.ts
@@ -1,0 +1,17 @@
+import { generateNbtStrings } from '@/lib/nbt'
+import type {
+  ExportedNBTGeneratorWorkerMessage,
+  ExportedNBTGeneratorWorkerResponse,
+} from '@/types/workers'
+
+// Worker Message Handler
+self.onmessage = (evt: MessageEvent<ExportedNBTGeneratorWorkerMessage>) => {
+  const msg = evt.data
+  if (msg.cmd === 'generate') {
+    const result = generateNbtStrings(msg.data)
+    self.postMessage({
+      type: 'data',
+      data: result,
+    } satisfies ExportedNBTGeneratorWorkerResponse)
+  }
+}


### PR DESCRIPTION
모든 디스플레이 엔티티에 커스텀 nbt 값을 넣을 수 있도록 추가하는 #60 을 진행하면서, 마인크래프트 명령어 생성 과정에 nbt 값을 검사하는 로직을 추가했었습니다.

하지만 엔티티 수가 100개를 넘어가는 프로젝트에서 nbt 값을 검사하면서 명령어를 생성할 경우 `마인크래프트로 내보내기` 창을 띄울 때 상당히 느려지는 현상이 확인되었습니다. 브라우저 개발자 도구로 확인해 보니, 새로 추가한 nbt 파싱에서 가장 많은 시간이 소요되었습니다.
파서를 교체하는 것 외에는 근본적인 해결책이 보이지 않았고 브라우저에서 빠른 속도로 돌아가는 마땅한 대체 파서를 찾을 수 없어, 결국 #60 PR 전의 명령어 생성 로직을 다시 도입하고 nbt 값 검사를 선택사항으로 변경하였습니다 (기본값은 비활성화입니다)

## 변경사항
- nbt 검사 사용 여부 옵션을 추가했습니다. 설정 > 일반 페이지에 있으며, 기본값은 `false`입니다.
- nbt 검사를 사용할 경우, 명령어에 들어가는 nbt 데이터 생성 로직을 Web Worker에서 실행합니다.
  - Web Worker를 사용하지 않을 경우 명령어를 생성하는 동안 전체 UI가 멈춰버려 사용자한테 좋지 않은 경험을 줍니다. (명령어 생성 로직은 비동기가 아닙니다)
- 마인크래프트로 내보내기 창에서 `baseTag`를 수정할 경우 0.2초의 대기시간 이후에 명령어가 생성되도록 변경했습니다. 대기시간 전에 값을 수정할 경우 기존 대기를 취소하고 다시 대기합니다.
  - 짧은 시간 안에 값을 바꾸는 경우 그만큼 동시에 명령어 생성이 실행되어 렉이 지속적으로 걸리는 것을 방지합니다.
- Web Worker를 사용하여 명령어를 생성하는 경우, 비동기 처리인 만큼 생성 중임을 알리는 표시를 넣었습니다.

## 기타
- 추후에 빠른 속도의 nbt 파서를 찾거나, 혹은 직접 만들게 되면 다시 한 번 로직이 변경될 수도 있습니다.