### PR TITLE
feat(app): add ways to recover from unexpected crash

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -37,6 +37,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.3.8",
+    "react-error-boundary": "^6.1.2",
     "react-i18next": "^17.0.6",
     "react-icons": "^5.5.0",
     "sonner": "^2.0.7",

--- a/packages/app/public/locales/en/translation.json
+++ b/packages/app/public/locales/en/translation.json
@@ -350,5 +350,11 @@
     "group": "Group",
     "selectAll": "Select All",
     "delete": "Delete"
+  },
+  "crashFallback": {
+    "title": "DEPL just crashed by an unexpected error",
+    "tryRecover": "Try Recover",
+    "reloadApp": "Reload App",
+    "downloadAutosave": "Download the latest autosave"
   }
 }

--- a/packages/app/public/locales/ko/translation.json
+++ b/packages/app/public/locales/ko/translation.json
@@ -355,5 +355,11 @@
     "group": "그룹",
     "selectAll": "전체 선택",
     "delete": "삭제"
+  },
+  "crashFallback": {
+    "title": "DEPL이 예기치 못한 오류로 인해 다운되었습니다",
+    "tryRecover": "복구 시도",
+    "reloadApp": "앱 다시 로드",
+    "downloadAutosave": "가장 최신의 자동저장 데이터 다운로드"
   }
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -5,7 +5,7 @@ import {
   type FallbackProps,
   getErrorMessage,
 } from 'react-error-boundary'
-import { LuAmbulance, LuCircleX, LuRotateCcw } from 'react-icons/lu'
+import { LuAmbulance, LuCircleX, LuDownload, LuRotateCcw } from 'react-icons/lu'
 
 import ContextMenuHandler from './components/ContextMenuHandler'
 import FileDropzone from './components/FileDropzone'
@@ -26,6 +26,7 @@ import { Button } from './components/ui/button'
 import { TooltipProvider } from './components/ui/tooltip'
 import { queryClient } from './lib/query.ts'
 import AutosaveService from './lib/services/autosave.service.ts'
+import { downloadFile } from './lib/utils'
 import { useDialogStore } from './stores/dialogStore'
 import { useEditorStore } from './stores/editorStore'
 import { useProjectStore } from './stores/projectStore.ts'
@@ -49,7 +50,7 @@ const CrashFallback: FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
       <pre className="max-h-[50dvh] overflow-auto text-wrap">
         {getErrorMessage(error)}
       </pre>
-      <div className="flex w-full flex-col justify-center gap-2 sm:flex-row">
+      <div className="flex w-full flex-col gap-2 sm:flex-row sm:justify-center">
         <Button size="lg" onClick={resetErrorBoundary}>
           <LuAmbulance /> Try Recover
         </Button>
@@ -61,6 +62,19 @@ const CrashFallback: FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
           <LuRotateCcw /> Reload App
         </Button>
       </div>
+
+      <Button
+        variant="outline"
+        className="w-full sm:w-auto"
+        onClick={() => {
+          const saveDataBlob = AutosaveService.instance.getSave()
+          if (saveDataBlob != null) {
+            downloadFile(saveDataBlob, `depl-autosave-${Date.now()}.depl`)
+          }
+        }}
+      >
+        <LuDownload /> Download the latest autosave
+      </Button>
     </div>
   )
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,5 +1,11 @@
 import { QueryClientProvider } from '@tanstack/react-query'
 import { type FC, useEffect } from 'react'
+import {
+  ErrorBoundary,
+  type FallbackProps,
+  getErrorMessage,
+} from 'react-error-boundary'
+import { LuAmbulance, LuCircleX, LuRotateCcw } from 'react-icons/lu'
 
 import ContextMenuHandler from './components/ContextMenuHandler'
 import FileDropzone from './components/FileDropzone'
@@ -16,6 +22,7 @@ import Modal from './components/dialog/Modal.tsx'
 import PlayerHeadBakingDialog from './components/dialog/PlayerHeadBakingDialog'
 import SettingsDialog from './components/dialog/SettingsDialog'
 import WelcomeDialog from './components/dialog/WelcomeDialog'
+import { Button } from './components/ui/button'
 import { TooltipProvider } from './components/ui/tooltip'
 import { queryClient } from './lib/query.ts'
 import AutosaveService from './lib/services/autosave.service.ts'
@@ -32,6 +39,30 @@ const BrowserTitleHandler: FC = () => {
   }, [projectName, projectDirty])
 
   return null
+}
+
+const CrashFallback: FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-4 text-center">
+      <LuCircleX size={128} />
+      <p className="text-2xl">DEPL just crashed by an unexpected error</p>
+      <pre className="max-h-[50dvh] overflow-auto text-wrap">
+        {getErrorMessage(error)}
+      </pre>
+      <div className="flex w-full flex-col justify-center gap-2 sm:flex-row">
+        <Button size="lg" onClick={resetErrorBoundary}>
+          <LuAmbulance /> Try Recover
+        </Button>
+        <Button
+          size="lg"
+          variant="secondary"
+          onClick={() => window.location.reload()}
+        >
+          <LuRotateCcw /> Reload App
+        </Button>
+      </div>
+    </div>
+  )
 }
 
 function App() {
@@ -59,40 +90,42 @@ function App() {
   }, [])
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider delay={300}>
-        <div className="relative flex h-full w-full overflow-hidden">
-          <div className="relative h-full flex-1 overflow-hidden">
-            {/* overflow-hidden is required to prevent child canvas width height from affecting parent div
+    <ErrorBoundary fallbackRender={(props) => <CrashFallback {...props} />}>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider delay={300}>
+          <div className="relative flex h-full w-full overflow-hidden">
+            <div className="relative h-full flex-1 overflow-hidden">
+              {/* overflow-hidden is required to prevent child canvas width height from affecting parent div
               and correctly measure parent container size for canvas resizing */}
-            <ContextMenuHandler triggerClassName="h-full w-full">
-              <Scene />
-            </ContextMenuHandler>
+              <ContextMenuHandler triggerClassName="h-full w-full">
+                <Scene />
+              </ContextMenuHandler>
 
-            {/* floating buttons */}
-            <LeftButtonPanel />
-            <QuickActionPanel />
-            <MobileBottomButtonPanel />
+              {/* floating buttons */}
+              <LeftButtonPanel />
+              <QuickActionPanel />
+              <MobileBottomButtonPanel />
+            </div>
+
+            <Sidebar />
+
+            <WelcomeDialog />
+            <Modal />
+            <SettingsDialog />
+            <BlockDisplaySelectDialog />
+            <ItemDisplaySelectDialog />
+            <ExportToMinecraftDialog />
+            <PlayerHeadBakingDialog />
+
+            <FileDropzone />
           </div>
 
-          <Sidebar />
+          <BrowserTitleHandler />
 
-          <WelcomeDialog />
-          <Modal />
-          <SettingsDialog />
-          <BlockDisplaySelectDialog />
-          <ItemDisplaySelectDialog />
-          <ExportToMinecraftDialog />
-          <PlayerHeadBakingDialog />
-
-          <FileDropzone />
-        </div>
-
-        <BrowserTitleHandler />
-
-        <ToastContainer />
-      </TooltipProvider>
-    </QueryClientProvider>
+          <ToastContainer />
+        </TooltipProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   )
 }
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -5,6 +5,7 @@ import {
   type FallbackProps,
   getErrorMessage,
 } from 'react-error-boundary'
+import { useTranslation } from 'react-i18next'
 import { LuAmbulance, LuCircleX, LuDownload, LuRotateCcw } from 'react-icons/lu'
 
 import ContextMenuHandler from './components/ContextMenuHandler'
@@ -43,23 +44,25 @@ const BrowserTitleHandler: FC = () => {
 }
 
 const CrashFallback: FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
+  const { t } = useTranslation()
+
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-4 text-center">
       <LuCircleX size={128} />
-      <p className="text-2xl">DEPL just crashed by an unexpected error</p>
+      <p className="text-2xl">{t(($) => $.crashFallback.title)}</p>
       <pre className="max-h-[50dvh] overflow-auto text-wrap">
         {getErrorMessage(error)}
       </pre>
       <div className="flex w-full flex-col gap-2 sm:flex-row sm:justify-center">
         <Button size="lg" onClick={resetErrorBoundary}>
-          <LuAmbulance /> Try Recover
+          <LuAmbulance /> {t(($) => $.crashFallback.tryRecover)}
         </Button>
         <Button
           size="lg"
           variant="secondary"
           onClick={() => window.location.reload()}
         >
-          <LuRotateCcw /> Reload App
+          <LuRotateCcw /> {t(($) => $.crashFallback.reloadApp)}
         </Button>
       </div>
 
@@ -73,7 +76,7 @@ const CrashFallback: FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
           }
         }}
       >
-        <LuDownload /> Download the latest autosave
+        <LuDownload /> {t(($) => $.crashFallback.downloadAutosave)}
       </Button>
     </div>
   )

--- a/packages/app/src/components/dialog/settings/DebugOptionsPage.tsx
+++ b/packages/app/src/components/dialog/settings/DebugOptionsPage.tsx
@@ -1,5 +1,5 @@
 import { reloadResources } from 'i18next'
-import type { FC } from 'react'
+import { type FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { useShallow } from 'zustand/shallow'
@@ -20,6 +20,16 @@ const DebugOptionsPage: FC = () => {
       setSettings: state.setSettings,
     })),
   )
+
+  const [throwErrorFlag, setThrowErrorFlag] = useState(false)
+  useEffect(() => {
+    // when flag is set, flip the flag to false and force crash
+    if (throwErrorFlag) {
+      setThrowErrorFlag(false)
+
+      throw new Error('Intentionally thrown Error')
+    }
+  }, [throwErrorFlag])
 
   return (
     <>
@@ -142,6 +152,19 @@ const DebugOptionsPage: FC = () => {
           >
             Reload translations
           </Button>
+        </div>
+
+        <div className="flex flex-col gap-2 rounded bg-red-50 p-2 dark:bg-red-950">
+          <div className="text-lg">Danger Zone</div>
+          <div className="flex gap-2">
+            <Button
+              onClick={() => {
+                setThrowErrorFlag(true)
+              }}
+            >
+              Throw React Error
+            </Button>
+          </div>
         </div>
       </FieldGroup>
     </>

--- a/packages/app/src/lib/services/autosave.service.ts
+++ b/packages/app/src/lib/services/autosave.service.ts
@@ -72,17 +72,27 @@ export default class AutosaveService {
     return window.localStorage.getItem(AUTOSAVE_KEY) != null
   }
 
-  async loadSave() {
+  getSave() {
     const saveDataEncoded = window.localStorage.getItem(AUTOSAVE_KEY)
     if (saveDataEncoded == null) {
-      throw new Error('Autosave data does not exist')
+      logger.warn('Autosave data does not exist')
+      return null
     }
 
     logger.log('loading autosaved data')
 
     // base64 decode
     const saveData = decodeBase64ToBinary(saveDataEncoded)
-    await openFromFile(new Blob([saveData]))
+    return new Blob([saveData])
+  }
+
+  async loadSave() {
+    const saveDataBlob = this.getSave()
+    if (saveDataBlob == null) {
+      throw new Error('Autosave data does not exist')
+    }
+
+    await openFromFile(saveDataBlob)
   }
 
   deleteSave() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       react-dropzone:
         specifier: ^14.3.8
         version: 14.3.8(react@18.3.1)
+      react-error-boundary:
+        specifier: ^6.1.2
+        version: 6.1.2(react@18.3.1)
       react-i18next:
         specifier: ^17.0.6
         version: 17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
@@ -2960,6 +2963,11 @@ packages:
     engines: {node: '>= 10.13'}
     peerDependencies:
       react: '>= 16.8 || 18.0.0'
+
+  react-error-boundary@6.1.2:
+    resolution: {integrity: sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
 
   react-i18next@17.0.6:
     resolution: {integrity: sha512-WzJ6SMKF+GTD7JZZqxSR1AKKmXjaSu39sClUrNlwxS4Tl7a99O+ltFy6yhPMO+wgZuxpQjJ2PZkfrQKmAqrLhw==}
@@ -6243,6 +6251,10 @@ snapshots:
       attr-accept: 2.2.5
       file-selector: 2.1.2
       prop-types: 15.8.1
+      react: 18.3.1
+
+  react-error-boundary@6.1.2(react@18.3.1):
+    dependencies:
       react: 18.3.1
 
   react-i18next@17.0.6(i18next@26.0.8(typescript@6.0.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3):


### PR DESCRIPTION
React 렌더링이나 effect 실행 중 예상치 못한 오류가 발생했을 때 오류를 복구하고 작업을 계속하거나, 가장 최신의 자동저장 데이터를 다운로드할 수 있는 화면을 추가합니다.

예상치 못한 오류는 언제든지 발생할 수 있습니다. 개발하는 동안 발생할 수 있는 오류에 대하여 대응을 해두지만, 미처 발견하지 못한 케이스가 있을 수 있습니다. 현재 상태에서는 React 렌더링 중이나 effect 실행 중 catch되지 않은 오류가 발생하면 모든 컴포넌트가 사라지고 빈 화면만 남게 됩니다. 이 상태에서는 앱을 다시 로드하는 것 이외에는 아무것도 할 수 없게 되고, 자연스럽게 작업 중이던 프로젝트도 손실이 발생할 수밖에 없습니다.

이를 개선하고자 예상치 못한 오류가 발생할 경우 빈 화면 대신 오류 상태를 리셋하고 복구하는 버튼이 있는 UI가 나오게 추가했습니다. 오류 중 일부분은 지속적이거나 치명적이지 않은 오류로, 오류 상태를 해소하고 계속 작업을 진행하거나 정상적으로 프로젝트를 저장할 수 있게 할 수 있습니다.

오류 상태 복구가 불가능할 경우 앱을 다시 로드하거나, 브라우저에 저장되어 있는 자동저장 데이터를 바로 다운받을 수 있는 기능도 추가했습니다. 알 수 없는 이유로 인해 앱을 로드하는 중에 오류가 발생할 경우 도움이 될 수 있습니다.

- 예상치 못한 오류 발생 시 핸들링하는 ErrorBoundary를 추가했습니다.
- 오류 상태를 리셋하고 복구하는 버튼을 ErrorBoundary fallback에 추가했습니다.
- 브라우저에 저장되어 있는 자동저장 데이터를 바로 다운받을 수 있는 버튼을 ErrorBoundary fallback에 추가했습니다.
- 개발 목적이나 테스트 목적으로 확인할 수 있도록 설정 > 디버그 옵션에 강제로 오류를 발생시키는 버튼을 추가했습니다.