### PR TITLE
perf(app): reduce object matrix auto update

### DIFF
--- a/packages/app/src/components/DisplayEntitiesRootGroup.tsx
+++ b/packages/app/src/components/DisplayEntitiesRootGroup.tsx
@@ -18,7 +18,11 @@ const DisplayentitiesRootGroup: FC = () => {
   )
 
   return (
-    <group name="Display Entities" ref={rootGroupRefData.objectRef}>
+    <group
+      name="Display Entities"
+      ref={rootGroupRefData.objectRef}
+      matrixAutoUpdate={false}
+    >
       {entityIds.map((id) => (
         <DisplayEntity key={id} id={id} />
       ))}

--- a/packages/app/src/components/InstancedMeshesRootGroup.tsx
+++ b/packages/app/src/components/InstancedMeshesRootGroup.tsx
@@ -70,7 +70,7 @@ const InstancedMeshBatch: FC<InstancedMeshBatchProps> = ({ batchInfo }) => {
 export const InstancedMeshesRootGroup: FC = () => {
   const batches = useInstancedMeshStore((state) => state.batches)
   return (
-    <group name="InstancedMesh Root Group">
+    <group name="InstancedMesh Root Group" matrixAutoUpdate={false}>
       {[...batches.values()].map((batchInfo) => (
         <InstancedMeshBatch key={batchInfo.key} batchInfo={batchInfo} />
       ))}

--- a/packages/app/src/components/Scene.tsx
+++ b/packages/app/src/components/Scene.tsx
@@ -78,7 +78,7 @@ const Axes: FC<AxesProps> = ({ lineScale }) => {
     ref.current?.setColors(...AxesColors)
   }, [])
 
-  return <axesHelper args={[lineScale]} ref={ref} />
+  return <axesHelper args={[lineScale]} ref={ref} matrixAutoUpdate={false} />
 }
 
 const Scene: FC = () => {
@@ -123,6 +123,7 @@ const Scene: FC = () => {
       frameloop="demand"
       scene={{
         background: new Color(0x222222),
+        matrixAutoUpdate: false,
       }}
       gl={{
         antialias: false,

--- a/packages/app/src/components/TransformControls.tsx
+++ b/packages/app/src/components/TransformControls.tsx
@@ -444,6 +444,9 @@ const TransformControls: FC = () => {
 
               transformData.object.scale.copy(scaleToApply)
             }
+
+            // manually update matrix since matrixAutoUpdate is disabled on entities
+            transformData.object.updateMatrix()
           }
 
           if (selectedEntityIds.length > 0) {

--- a/packages/app/src/components/TransformControls.tsx
+++ b/packages/app/src/components/TransformControls.tsx
@@ -1,3 +1,4 @@
+import { useRafCallback } from '@react-hookz/web'
 import { TransformControls as TransformControlsImpl } from '@react-three/drei'
 import { invalidate } from '@react-three/fiber'
 import {
@@ -21,7 +22,7 @@ import {
   Quaternion,
   Vector3,
 } from 'three'
-import { TransformControls as OriginalTransformControls } from 'three/examples/jsm/Addons.js'
+import type { TransformControls as OriginalTransformControls } from 'three/examples/jsm/Addons.js'
 import { useShallow } from 'zustand/shallow'
 
 import { batchSetEntityTransformation } from '@/lib/entities'
@@ -250,6 +251,104 @@ const TransformControls: FC = () => {
     }
   }, [])
 
+  const [handleObjectChangeFrameSync] = useRafCallback(
+    ({ axis }: { axis: OriginalTransformControls['axis'] }) => {
+      // scale은 양수 값만 가질 수 있음
+      const absoluteScale = pivot.scale.toArray().map(Math.abs) as Number3Tuple
+      // state를 건드리기 전에 object3d에 먼저 scale 값을 세팅해야 음수 값일 경우 음수 <-> 양수로 계속 바뀌면서 생기는 깜빡거림을 방지할 수 있음
+      pivot.scale.fromArray(absoluteScale)
+
+      const pivotQuat = pivot.quaternion.clone()
+      const pivotQuatDelta = pivotQuat
+        .clone()
+        .multiply(pivotInitialQuaternion.current.clone().invert())
+
+      const pivotWorldQuat = new Quaternion()
+      pivot.getWorldQuaternion(pivotWorldQuat)
+
+      // share objects inside loop instead of creating new one every iteration
+      const relativePosFromPivot = new Vector3()
+      const newPos = new Vector3()
+      const newQuat = new Quaternion()
+
+      const alteredScale = new Vector3()
+      const scaleToApply = new Vector3()
+
+      const sharedParent =
+        selectedEntityInitialTransformations.current[0].object.parent!
+
+      // 1. Get the shared parent's world quaternion
+      const parentQuatWorld = new Quaternion()
+      sharedParent.getWorldQuaternion(parentQuatWorld)
+
+      // 2. Precompute conversion (used for all children)
+      for (const transformData of selectedEntityInitialTransformations.current) {
+        if (mode !== 'scale') {
+          relativePosFromPivot
+            .copy(transformData.position)
+            .sub(pivotInitialPosition.current)
+
+          if (mode === 'rotate') {
+            // apply pivot quaternion delta to object initial quaternion
+            newQuat.copy(pivotQuatDelta).multiply(transformData.quaternion)
+            transformData.object.quaternion.copy(newQuat)
+          }
+
+          // FIXME: rotating an object inside scaled parent makes object stretched when rotated
+
+          newPos
+            .copy(relativePosFromPivot)
+            .applyQuaternion(pivotQuatDelta)
+            .add(pivot.position)
+
+          transformData.object.position.copy(newPos)
+        } else {
+          alteredScale.copy(transformData.scale).multiply(pivot.scale)
+          scaleToApply.copy(transformData.scale)
+          ;(['x', 'y', 'z'] as const).forEach((axis) => {
+            if (axis != null && axis.toLowerCase().includes(axis)) {
+              const initialAxisScale = transformData.scale[axis]
+              const axisScaleDiff = alteredScale[axis] - initialAxisScale
+
+              let finalAxisScale =
+                initialAxisScale +
+                Math.round(axisScaleDiff / SCALE_SNAP) * SCALE_SNAP
+              finalAxisScale = Math.max(
+                Math.abs(finalAxisScale),
+                Number.EPSILON,
+              )
+
+              scaleToApply[axis] = finalAxisScale
+            }
+          })
+
+          transformData.object.scale.copy(scaleToApply)
+        }
+
+        // manually update matrix since matrixAutoUpdate is disabled on entities
+        transformData.object.updateMatrix()
+      }
+
+      if (selectedEntityIds.length > 0) {
+        const firstSelectedEntityRefData = useEntityRefStore
+          .getState()
+          .entityRefs.get(selectedEntityIds[0])!
+
+        setSelectionBaseTransformation({
+          position:
+            firstSelectedEntityRefData.objectRef.current.position.toArray(),
+          rotation: firstSelectedEntityRefData.objectRef.current.rotation
+            .toArray()
+            .slice(0, 3) as [number, number, number],
+          size: firstSelectedEntityRefData.objectRef.current.scale.toArray(),
+        })
+      }
+
+      // update box
+      updateBoundingBox()
+    },
+  )
+
   return (
     <>
       <TransformControlsImpl
@@ -366,106 +465,12 @@ const TransformControls: FC = () => {
 
           pivot.scale.set(1, 1, 1)
         }}
-        onObjectChange={(e) => {
-          const target = (e as Event<string, OriginalTransformControls>).target
-          // scale은 양수 값만 가질 수 있음
-          const absoluteScale = target.object.scale
-            .toArray()
-            .map(Math.abs) as Number3Tuple
-          // state를 건드리기 전에 object3d에 먼저 scale 값을 세팅해야 음수 값일 경우 음수 <-> 양수로 계속 바뀌면서 생기는 깜빡거림을 방지할 수 있음
-          target.object.scale.fromArray(absoluteScale)
+        onObjectChange={(evt) => {
+          if (evt == null) return
 
-          const pivotQuat = pivot.quaternion.clone()
-          const pivotQuatDelta = pivotQuat
-            .clone()
-            .multiply(pivotInitialQuaternion.current.clone().invert())
-
-          const pivotWorldQuat = new Quaternion()
-          pivot.getWorldQuaternion(pivotWorldQuat)
-
-          // share objects inside loop instead of creating new one every iteration
-          const relativePosFromPivot = new Vector3()
-          const newPos = new Vector3()
-          const newQuat = new Quaternion()
-
-          const alteredScale = new Vector3()
-          const scaleToApply = new Vector3()
-
-          const sharedParent =
-            selectedEntityInitialTransformations.current[0].object.parent!
-
-          // 1. Get the shared parent's world quaternion
-          const parentQuatWorld = new Quaternion()
-          sharedParent.getWorldQuaternion(parentQuatWorld)
-
-          // 2. Precompute conversion (used for all children)
-          for (const transformData of selectedEntityInitialTransformations.current) {
-            if (mode !== 'scale') {
-              relativePosFromPivot
-                .copy(transformData.position)
-                .sub(pivotInitialPosition.current)
-
-              if (mode === 'rotate') {
-                // apply pivot quaternion delta to object initial quaternion
-                newQuat.copy(pivotQuatDelta).multiply(transformData.quaternion)
-                transformData.object.quaternion.copy(newQuat)
-              }
-
-              // FIXME: rotating an object inside scaled parent makes object stretched when rotated
-
-              newPos
-                .copy(relativePosFromPivot)
-                .applyQuaternion(pivotQuatDelta)
-                .add(pivot.position)
-
-              transformData.object.position.copy(newPos)
-            } else {
-              alteredScale.copy(transformData.scale).multiply(pivot.scale)
-              scaleToApply.copy(transformData.scale)
-              ;(['x', 'y', 'z'] as const).forEach((axis) => {
-                if (
-                  target.axis != null &&
-                  target.axis.toLowerCase().includes(axis)
-                ) {
-                  const initialAxisScale = transformData.scale[axis]
-                  const axisScaleDiff = alteredScale[axis] - initialAxisScale
-
-                  let finalAxisScale =
-                    initialAxisScale +
-                    Math.round(axisScaleDiff / SCALE_SNAP) * SCALE_SNAP
-                  finalAxisScale = Math.max(
-                    Math.abs(finalAxisScale),
-                    Number.EPSILON,
-                  )
-
-                  scaleToApply[axis] = finalAxisScale
-                }
-              })
-
-              transformData.object.scale.copy(scaleToApply)
-            }
-
-            // manually update matrix since matrixAutoUpdate is disabled on entities
-            transformData.object.updateMatrix()
-          }
-
-          if (selectedEntityIds.length > 0) {
-            const firstSelectedEntityRefData = useEntityRefStore
-              .getState()
-              .entityRefs.get(selectedEntityIds[0])!
-
-            setSelectionBaseTransformation({
-              position:
-                firstSelectedEntityRefData.objectRef.current.position.toArray(),
-              rotation: firstSelectedEntityRefData.objectRef.current.rotation
-                .toArray()
-                .slice(0, 3) as [number, number, number],
-              size: firstSelectedEntityRefData.objectRef.current.scale.toArray(),
-            })
-          }
-
-          // update box
-          updateBoundingBox()
+          handleObjectChangeFrameSync({
+            axis: (evt as Event<string, OriginalTransformControls>).target.axis,
+          })
         }}
       />
 

--- a/packages/app/src/components/canvas/BlockDisplay.tsx
+++ b/packages/app/src/components/canvas/BlockDisplay.tsx
@@ -83,14 +83,18 @@ const BlockDisplay: FC<BlockDisplayProps> = ({
   if (thisEntity?.kind !== 'block') return null
 
   return (
-    <zeroScaledGroup ref={ref} name={`BlockDisplay ${id} ${type}`}>
+    <zeroScaledGroup
+      ref={ref}
+      name={`BlockDisplay ${id} ${type}`}
+      matrixAutoUpdate={false}
+    >
       <BoundingBoxForInstanced
         modelList={modelList}
         visible={thisEntitySelected}
         color="gold"
       />
 
-      <group onClick={onClick}>
+      <group onClick={onClick} matrixAutoUpdate={false}>
         {matchingBlockstatesModels.map((modelToApply, idx) => {
           const resourceLocation = modelToApply.model
           const modelId = `${id}|${resourceLocation}|x:${modelToApply.x}|y:${modelToApply.y}|${idx}`

--- a/packages/app/src/components/canvas/BoundingBox.tsx
+++ b/packages/app/src/components/canvas/BoundingBox.tsx
@@ -27,6 +27,7 @@ const OriginVec = new Vector3()
 const DisplayTranslationMinVec = new Vector3(-80, -80, -80)
 const DisplayTranslationMaxVec = new Vector3(80, 80, 80)
 
+const IdentityMatrix = new Matrix4()
 const HalfBlockTranslatedMatrix = new Matrix4().makeTranslation(0.5, 0.5, 0.5)
 const ReverseHalfBlockTranslatedMatrix = new Matrix4().makeTranslation(
   -0.5,
@@ -61,13 +62,13 @@ export const BoundingBox: FC<BoundingBoxProps> = ({
 
     // BoxHelper가 object의 transformation이 초기 상태일 때만 위치와 크기를 제대로 계산하는 것으로 보임
     // 따라서 초기 상태로 만든 다음 setFromObject() 호출 후 되돌리기
-    const m = object.matrix.clone()
-    const freshMatrix = new Matrix4()
-    freshMatrix.decompose(object.position, object.quaternion, object.scale)
+    const matrixBackup = object.matrix.clone()
+    IdentityMatrix.decompose(object.position, object.quaternion, object.scale)
+    object.updateMatrix()
 
     boxHelperRef.current.setFromObject(object)
 
-    m.decompose(object.position, object.quaternion, object.scale)
+    matrixBackup.decompose(object.position, object.quaternion, object.scale)
     object.updateMatrix()
 
     // Prevent the helpers from blocking rays
@@ -80,7 +81,7 @@ export const BoundingBox: FC<BoundingBoxProps> = ({
       parent.add(object)
     }
 
-    object.updateMatrixWorld() // needed to correctly calculate world matrix after all jobs
+    object.updateWorldMatrix(true, true) // needed to correctly calculate world matrix after all jobs
   })
 
   return (
@@ -90,6 +91,7 @@ export const BoundingBox: FC<BoundingBoxProps> = ({
       ref={boxHelperRef}
       // disable click detection for BoxHelper (r3f automatically enables it by default)
       raycast={() => {}}
+      matrixAutoUpdate={false}
     />
   )
 }

--- a/packages/app/src/components/canvas/DisplayEntityGroup.tsx
+++ b/packages/app/src/components/canvas/DisplayEntityGroup.tsx
@@ -1,7 +1,8 @@
-import { type ThreeEvent, useFrame } from '@react-three/fiber'
-import { type FC, type MutableRefObject, useEffect } from 'react'
+import type { Number3Tuple } from '@depl/shared'
+import { type ThreeEvent, invalidate, useFrame } from '@react-three/fiber'
+import { type FC, type MutableRefObject, useEffect, useRef } from 'react'
 import { Group } from 'three'
-import { useShallow } from 'zustand/shallow'
+import { shallow, useShallow } from 'zustand/shallow'
 
 import { useDisplayEntityStore } from '@/stores/displayEntityStore'
 
@@ -43,17 +44,54 @@ const DisplayEntityGroup: FC<DisplayEntityGroupProps> = ({
 
     const { position, rotation, size } = thisEntity
 
-    ref?.current?.position.set(...position)
-    ref?.current?.rotation.set(...rotation)
-    ref?.current?.scale.set(...size)
+    if (ref?.current != null) {
+      ref.current.position.set(...position)
+      ref.current.rotation.set(...rotation)
+      ref.current.scale.set(...size)
+
+      ref.current.updateMatrix()
+      ref.current.matrixWorldNeedsUpdate = true
+      invalidate()
+    }
   }, [id, ref])
+
+  const prevTransformRef = useRef<{
+    position: Number3Tuple
+    rotation: Number3Tuple
+    scale: Number3Tuple
+  }>({
+    position: [0, 0, 0],
+    rotation: [0, 0, 0],
+    scale: [1, 1, 1],
+  })
 
   // 매 프레임 렌더링 시마다 선택되어 있지 않을 경우 transformation 설정
   useFrame(() => {
-    if (!thisEntitySelected) {
-      ref?.current?.position.set(...position)
-      ref?.current?.rotation.set(...rotation)
-      ref?.current?.scale.set(...size)
+    const {
+      position: prevPosition,
+      rotation: prevRotation,
+      scale: prevScale,
+    } = prevTransformRef.current
+    if (
+      shallow(prevPosition, position) &&
+      shallow(prevRotation, rotation) &&
+      shallow(prevScale, size)
+    ) {
+      // transform data is unchanged
+      return
+    }
+
+    if (!thisEntitySelected && ref?.current != null) {
+      ref.current.position.set(...position)
+      ref.current.rotation.set(...rotation)
+      ref.current.scale.set(...size)
+
+      ref.current.updateMatrix()
+      invalidate()
+
+      prevTransformRef.current.position = position
+      prevTransformRef.current.rotation = rotation
+      prevTransformRef.current.scale = size
     }
   })
 
@@ -62,6 +100,7 @@ const DisplayEntityGroup: FC<DisplayEntityGroupProps> = ({
       ref={ref as MutableRefObject<Group>}
       name={`DisplayEntityGroup ${id}`}
       onClick={onClick}
+      matrixAutoUpdate={false}
     >
       {/* 그룹 안에 들어가야 할 display entity들은 portal을 사용해서 이 안에서 렌더링됨 */}
       <BoundingBox

--- a/packages/app/src/components/canvas/ItemDisplay.tsx
+++ b/packages/app/src/components/canvas/ItemDisplay.tsx
@@ -99,7 +99,11 @@ const ItemDisplay: FC<ItemDisplayProps> = ({
   )
 
   return (
-    <zeroScaledGroup ref={ref} name={`ItemDisplay ${id} ${type}`}>
+    <zeroScaledGroup
+      ref={ref}
+      name={`ItemDisplay ${id} ${type}`}
+      matrixAutoUpdate={false}
+    >
       {useInstancing ? (
         <BoundingBoxForInstanced
           modelList={modelList}
@@ -111,7 +115,11 @@ const ItemDisplay: FC<ItemDisplayProps> = ({
         thisEntitySelected && <Helper type={BoxHelper} args={['#06b6d4']} />
       )}
 
-      <group onClick={onClick} ref={boundingBoxTargetRef}>
+      <group
+        onClick={onClick}
+        ref={boundingBoxTargetRef}
+        matrixAutoUpdate={false}
+      >
         {useInstancing ? (
           <MemoizedInstancedModel
             entityId={id}

--- a/packages/app/src/components/canvas/instanced.tsx
+++ b/packages/app/src/components/canvas/instanced.tsx
@@ -99,5 +99,5 @@ export const InstancedModel: FC<InstacedModelProps> = ({
     }
   })
 
-  return <group ref={objectRef} matrixWorldAutoUpdate />
+  return <group ref={objectRef} matrixAutoUpdate={false} />
 }

--- a/packages/app/src/stores/instancedMeshStore.ts
+++ b/packages/app/src/stores/instancedMeshStore.ts
@@ -89,6 +89,8 @@ export class InstancedMeshManager {
       )
       dummyMesh.instanceMatrix.needsUpdate = true
 
+      dummyMesh.matrixAutoUpdate = false
+
       const newBatch: InstancedMeshBatchData = {
         key: resourceLocation,
         status: 'loading', // indicate as loading
@@ -132,6 +134,8 @@ export class InstancedMeshManager {
           newMesh.instanceMatrix.needsUpdate = true
           newMesh.geometry.computeBoundingBox()
 
+          newMesh.matrixAutoUpdate = false
+
           batch.mesh.dispose()
 
           batch.mesh = newMesh
@@ -170,6 +174,8 @@ export class InstancedMeshManager {
           batch.capacity * 16,
         )
         newMesh.instanceMatrix.needsUpdate = true
+
+        newMesh.matrixAutoUpdate = false
 
         batch.mesh = newMesh
         batch.capacity *= 2


### PR DESCRIPTION
화면에 렌더링되는 오브젝트의 transformation matrix 자동 업데이트를 가능한 한 줄여, 아무것도 수정되지 않았는데도 매 프레임마다 자동으로 재계산되지 않도록 만듭니다.

Three.js는 기본적으로 scene에 렌더링되는 모든 Object3D, Box3 등의 객체들은 매 프레임마다 렌더링할 때 각각의 transformation local matrix와 world matrix를 자동으로 재계산하고, projection하는 등의 작업을 수행합니다.
depl에서는 디스플레이 엔티티 한 개당 약 5개의 Object3D가 화면에 렌더링되는데, 이들 모두 화면상으로 보이지 않는, transformation 잡는 용도의 빈 객체입니다. (실제로 화면에 보이는 블록/아이템들은 InstancedMesh를 사용해 렌더링되고, 이들은 같은 종류의 모델들을 한 번에 묶어 렌더링하기 때문에 성능에 영향을 별로 미치지 않습니다)

그런데 디스플레이 엔티티 수가 약 ~3000개 이상의 프로젝트를 로드하면 문제가 생기기 시작합니다. Scene 내부에 존재하는, 즉 매 프레임마다 matrix 계산해야 하는 객체 수가 몇 만 단위가 되면 구형 CPU에서 계산 시간이 늘어나고, 이 시간이 약 16.67ms를 넘어가면 60프레임 방어가 되지 않습니다.

이 문제의 원인은 두 가지로 나뉩니다:
- Three.js에서는 매 프레임마다 최상위 Scene에서부터 모든 자식 객체를 순회하며 transform matrix 재계산, projection 등의 작업을 수행합니다. 여러 단계로 중첩된 객체가 많을수록 순회에 걸리는 시간은 상당한 양으로 늘어납니다.
- 각 객체의 transform matrix를 계산할 때, `matrixAutoUpdate` 옵션이 활성화되어 있으면 local matrix를 계산하고, 그 이후 **world matrix를 계산합니다.** world matrix가 계산하는 데 상당한 시간이 소요됩니다.

이번 PR에서는 2번째 원인을 상당 부분 해결했습니다. `matrixAutoUpdate`의 기본값은 true이지만, 값 재계산이 필요없는 객체들은 이를 비활성화했습니다.
- BlockDisplay, ItemDisplay, DisplayEntityGroup, InstancedModel에서 렌더링되는 일부 `Group`들에 대해 비활성화했습니다.
- TextDisplay, ItemDisplay 중 플레이어 헤드 렌더링이라 InstancedModel을 사용하지 않는 경우는 적용되지 않았습니다. 이들은 대규모 리팩토링이 예정되어 있어 리팩토링을 진행할 때 수정할 예정입니다.

1번째 원인인 모든 자식 객체 순회로 인한 시간 소요 문제를 해결하려면 현재 에디터 내 렌더링 구조를 반쯤 갈아엎어야 하는 대규모 작업이므로 나중에 진행할 예정입니다.

### 성능 개선점 비교
블록 디스플레이가 \~6000개 있는 프로젝트에서 FPS를 32\~35 -> 40 정도로 소폭 개선했습니다.

테스트에 사용된 기기의 사양은 다음과 같습니다:
- CPU: Intel Core i5-8500
- RAM: 4GB
- GPU: 내장그래픽 (Intel(R) UHD Graphics 630)
- OS: Windows 10 (v1909)
- 브라우저: Chrome 150