### PR TITLE
release v1.10.1

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/app/src/components/canvas/Model.tsx
+++ b/packages/app/src/components/canvas/Model.tsx
@@ -16,6 +16,7 @@ import useModelData from '@/hooks/useModelData'
 import { getLogger } from '@/lib/logger'
 import { makeMaterial } from '@/lib/resources/material'
 import { generateModelMeshIngredients } from '@/lib/resources/modelMesh'
+import { stripSecondHeadLayer } from '@/lib/resources/player-head'
 import { stripMinecraftPrefix } from '@/lib/utils'
 import { useProjectStore } from '@/stores/projectStore'
 import type {
@@ -60,7 +61,7 @@ const Model: FC<ModelNewProps> = ({
   const [meshLoaded, setMeshLoaded] = useState(false)
 
   const prevResourceLocationRef = useRef(initialResourceLocation)
-  const prevPlayerHeadTextureDataRef = useRef(playerHeadData?.textureData)
+  const prevPlayerHeadDataRef = useRef(playerHeadData)
 
   const targetGameVersion = useProjectStore((state) => state.targetGameVersion)
 
@@ -93,22 +94,30 @@ const Model: FC<ModelNewProps> = ({
         )
         */
 
-        const prevPlayerHeadTextureData = prevPlayerHeadTextureDataRef.current
+        const prevPlayerHeadData = prevPlayerHeadDataRef.current
         if (
-          prevPlayerHeadTextureData?.baked === false &&
+          prevPlayerHeadData?.textureData.baked === false &&
           playerHeadData?.textureData.baked === false
         ) {
-          // prev and current has unbaked texture
-          if (
-            prevPlayerHeadTextureData?.paintTexturePixels !==
+          const textureChanged =
+            prevPlayerHeadData?.textureData.paintTexturePixels !==
             playerHeadData?.textureData.paintTexturePixels
-          ) {
+          const layerChanged =
+            prevPlayerHeadData?.showSecondLayer !==
+            playerHeadData?.showSecondLayer
+
+          // prev and current has unbaked texture
+          if (textureChanged || layerChanged) {
+            let paintTexturePixels =
+              playerHeadData.textureData.paintTexturePixels
+            if (!playerHeadData.showSecondLayer) {
+              paintTexturePixels = stripSecondHeadLayer(paintTexturePixels)
+            }
+
             // unbaked texture has changed, update material texture
             // console.log('just update material texture')
             const newTexture = new DataTexture(
-              new Uint8ClampedArray(
-                playerHeadData?.textureData.paintTexturePixels,
-              ),
+              new Uint8ClampedArray(paintTexturePixels),
               64,
               64,
             )
@@ -172,7 +181,7 @@ const Model: FC<ModelNewProps> = ({
           else old?.dispose()
         }
 
-        prevPlayerHeadTextureDataRef.current = playerHeadData?.textureData
+        prevPlayerHeadDataRef.current = playerHeadData
         invalidate()
         return
       }
@@ -207,7 +216,7 @@ const Model: FC<ModelNewProps> = ({
       }
       mergedMeshRef.current = newMesh
       prevResourceLocationRef.current = initialResourceLocation
-      prevPlayerHeadTextureDataRef.current = playerHeadData?.textureData
+      prevPlayerHeadDataRef.current = playerHeadData
 
       setMeshLoaded(true)
     }

--- a/packages/app/src/components/canvas/PlayerHeadPainter.tsx
+++ b/packages/app/src/components/canvas/PlayerHeadPainter.tsx
@@ -164,7 +164,7 @@ const PlayerHeadPainter: FC<PlayerHeadPainterProps> = ({
             playerHead: {
               baked: true,
               url: textureData.url,
-              showSecondLayer: headPainterLayer === 'second',
+              showSecondLayer: true, // we need the full layer data
             },
           })) // no resource fromVersion required on player_head
         } else {

--- a/packages/app/src/lib/resources/material.ts
+++ b/packages/app/src/lib/resources/material.ts
@@ -16,6 +16,8 @@ import {
 } from '@/stores/cacheStore'
 import { useProjectStore } from '@/stores/projectStore'
 
+import { stripSecondHeadLayer } from './player-head'
+
 const materialLoadMutexMap = new Map<string, Mutex>()
 
 type TextureData =
@@ -111,11 +113,12 @@ export async function makeMaterial(
 
   let texture: Texture
   if (textureData.type === 'player_head' && !textureData.playerHead.baked) {
-    texture = new DataTexture(
-      new Uint8ClampedArray(textureData.playerHead.paintTexturePixels),
-      64,
-      64,
-    )
+    let paintTexturePixels = textureData.playerHead.paintTexturePixels
+    if (!textureData.playerHead.showSecondLayer) {
+      paintTexturePixels = stripSecondHeadLayer(paintTexturePixels)
+    }
+
+    texture = new DataTexture(new Uint8ClampedArray(paintTexturePixels), 64, 64)
     texture.needsUpdate = true
     texture.flipY = true
   } else {

--- a/packages/app/src/lib/resources/player-head.ts
+++ b/packages/app/src/lib/resources/player-head.ts
@@ -1,0 +1,19 @@
+import { fill } from 'es-toolkit'
+
+export function stripSecondHeadLayer(texturePixels: number[]) {
+  // sanity check
+  if (texturePixels.length !== 64 * 64 * 4) {
+    throw new Error('Invalid texturePixels array length')
+  }
+
+  const arr = texturePixels.slice()
+
+  for (let y = 0; y < 16; y++) {
+    const start = y * 64 + 32
+    const end = y * 64 + 64
+
+    fill(arr, 0, start * 4, end * 4) // fill all rgba value to zero
+  }
+
+  return arr
+}


### PR DESCRIPTION
## 버그 수정
- 플레이어 헤드 페인터를 활성화한 후, 이미 구워진 헤드의 base layer를 수정하면 second layer 데이터가 없어지는 버그를 수정했습니다.
- 플레이어 헤드 페인터를 활성화한 후, 이미 구워진 헤드의 second layer를 수정한 뒤에 base layer로 변경할 경우 해당 플레이어 헤드가 현재 레이어를 무시하고 second layer를 띄우는 버그를 수정했습니다.

이 버그들은 최근에 발생한 것 같지는 않아 보입니다. 최악의 경우 **플레이어 헤드 페인터가 도입된 v1.7.0부터 해당 버그가 존재했을 수 있습니다.**
해당 버그들이 사실상 플레이어 헤드 페인터의 제대로 된 사용을 방해했을 것이라고 생각하여, 다음 기능 업데이트가 아닌 버그 수정으로 급히 올립니다. 우연히 발견했으니까 망정이지...